### PR TITLE
Add local agent runner tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@
 .config/configstore/
 .config/github-copilot/
 test/node_modules/
+.worktrees/
+__pycache__/
+*.pyc
+
+# Local-only u-agents runner config (example is tracked in config/)
+config/repositories.yml
+config/repositories.yaml

--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ Personal macOS development environment configuration.
 .claude/          Claude AI configuration
 .hammerspoon/     macOS automation
 agents/           Agent definitions
+u_agents/         Local tmux/GitHub agent runner
 skills/           Claude skills
 prompts/          Prompt templates
+examples/         Example local service definitions
+tests/            Tests for local tooling
 gh/               GitHub CLI extensions
 hooks/            Dev workflow hooks
 docs/             Documentation

--- a/config/repositories.example.yml
+++ b/config/repositories.example.yml
@@ -1,0 +1,27 @@
+# Local target repositories for the v0.1 agent runner.
+#
+# Each entry:
+#   full_name:       GitHub repo (owner/name)
+#   workspace_root:  absolute local path; main checkout and .worktrees/ live under it
+#   default_branch:  used to locate the main checkout (${workspace_root}/${default_branch})
+#   enabled:         whether the Launcher may operate on this repo (default: true)
+#
+# Required GitHub labels on each enabled repo:
+#   - status:ready        (issue is ready for the Launcher to pick up)
+#   - status:in-progress  (Launcher swaps to this after claim)
+
+repositories:
+  - full_name: your-org/trander-flutter
+    workspace_root: /Users/your-name/trander-flutter
+    default_branch: master
+    enabled: true
+
+  - full_name: your-org/trander-rust
+    workspace_root: /Users/your-name/trander-rust
+    default_branch: main
+    enabled: true
+
+  - full_name: your-org/u
+    workspace_root: /Users/your-name/u
+    default_branch: main
+    enabled: false

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,3 @@
 *
 !.gitignore
+!u-agents.md

--- a/docs/u-agents.md
+++ b/docs/u-agents.md
@@ -1,0 +1,298 @@
+# v0.1 local agent runner
+
+Small local runner around tmux + git + `gh` for the workflow described in
+[#5](https://github.com/uuta/u/issues/5). GitHub Issues / PRs / CI are the
+source of truth. There is no ops DB, no daemon, no vector store.
+
+## Components
+
+| Component  | Path                          | Role                                                                 |
+| ---------- | ----------------------------- | -------------------------------------------------------------------- |
+| Contract   | `u_agents/contract.py`          | Config types and deterministic tmux/worktree/branch naming.          |
+| Launcher   | `u_agents/launcher.py`          | Short-lived starter/resumer. Picks one ready issue and hands off PM. |
+| PM prompt  | `u_agents/prompts/pm.md`        | The contract sent into the PM pane. PM owns the per-issue workflow.  |
+| Watchdog   | `u_agents/watchdog.py`          | Detects stalled PM panes. Pings, then comments once if still stuck.  |
+| Config     | `config/repositories.yml`     | Local allowlist of repositories the Launcher may operate on.         |
+
+## Required tools
+
+- `python3` (>= 3.10)
+- `tmux`
+- `gh` (authenticated against the target repositories)
+- `claude` (Claude Code CLI; override with `U_AGENTS_CLAUDE_COMMAND` if needed)
+- `git`
+- `yq` (MikeFarah; only needed for YAML configs — `.json` configs do not require it)
+
+## Configuration
+
+Copy the example and edit:
+
+```sh
+mkdir -p ~/.config/u-agents
+cp config/repositories.example.yml ~/.config/u-agents/repositories.yml
+```
+
+Or keep the config in-repo at `config/repositories.yml` and pass `--config` explicitly.
+
+Discovery order when `--config` is omitted:
+
+1. `./config/repositories.yml`
+2. `./config/repositories.yaml`
+3. `~/.config/u-agents/repositories.yml`
+4. `~/.config/u-agents/repositories.yaml`
+
+Each entry:
+
+| Field            | Meaning                                                                  |
+| ---------------- | ------------------------------------------------------------------------ |
+| `full_name`      | GitHub `owner/name`.                                                     |
+| `workspace_root` | Absolute local path. Main checkout = `${workspace_root}/${default_branch}`. Worktrees = `${workspace_root}/.worktrees`. |
+| `default_branch` | Base branch for PRs and main checkout location.                          |
+| `enabled`        | If false, Launcher skips this repo.                                      |
+
+## Required GitHub labels
+
+The Launcher swaps these labels when claiming an issue. Create them on each
+enabled repo:
+
+- `status:ready` — issue is ready for an agent to claim.
+- `status:in-progress` — set by the Launcher when it claims an issue.
+
+If the labels do not exist, the Launcher aborts before creating a tmux
+window. Add the labels and re-run to enable proper queue semantics.
+
+Optional but recommended sizing labels: `size:s`, `size:m`, `size:l`.
+
+## Naming contract
+
+| Item             | Rule                                                       |
+| ---------------- | ---------------------------------------------------------- |
+| tmux session     | `agents`                                                   |
+| issue window     | `<repo-short>-<issue-number>` (e.g. `trander-flutter-233`) |
+| PM pane          | `agents:<window>.0` (pane title `pm`)                      |
+| worktree         | `${workspace_root}/.worktrees/<issue-number>`              |
+| branch           | `feat/<issue-number>`                                      |
+
+These names are deterministic. Both Launcher and Watchdog reconstruct them
+from `(repo, issue_number)` — no shared state file needed.
+
+## Commands
+
+### Launcher
+
+```sh
+# general run: resume any in-progress issue whose PM window is missing,
+# then claim one new status:ready issue
+python3 -m u_agents.launcher
+
+# direct lookup: act on this exact issue regardless of queue position.
+# - if status:ready  -> full claim + dispatch
+# - if status:in-progress -> resume (no label change, no claim comment)
+# - otherwise -> skip
+python3 -m u_agents.launcher --repo trander-flutter --issue 233
+
+# inspect what would happen without touching GitHub or tmux
+python3 -m u_agents.launcher --dry-run
+
+# alternate config path
+python3 -m u_agents.launcher --config ~/my-repos.yml
+```
+
+`--dry-run` suppresses all writes (label swap, claim comment, tmux window
+creation, prompt send) but still reads issue state from GitHub.
+
+#### Resume and partial-claim recovery
+
+Every general run first scans `status:in-progress` issues across enabled
+repos. For each whose deterministic tmux window is missing, the Launcher
+re-creates the window and re-sends the PM prompt. No label change happens
+during resume. Issues whose PM window is already alive are left alone (no
+duplicate dispatch).
+
+If `dispatch_claim` fails after the label swap (tmux unavailable, prompt
+send error, etc.), the Launcher attempts to roll the labels back to
+`status:ready` and cleans up any tmux window newly created by that failed
+handoff. If even the rollback fails, the next run's resume sweep re-creates
+the missing PM window from the `status:in-progress` state. Either way, no
+issue is silently stranded.
+
+Direct-lookup mode (`--issue N --repo R`) bypasses the queue and supports
+both fresh claim and resume of an already-claimed issue.
+
+### Watchdog
+
+```sh
+# single check pass and exit (useful from cron)
+python3 -m u_agents.watchdog --once
+
+# loop, checking every 60s
+python3 -m u_agents.watchdog --interval 60
+
+# tune stall threshold (default: 3 consecutive unchanged checks before ping)
+python3 -m u_agents.watchdog --interval 30 --stall-checks 4
+
+# dry-run skips ping send and GitHub comment, still writes state file
+python3 -m u_agents.watchdog --once --dry-run
+
+# OPT-IN: include the last 30 lines of the PM pane in the GitHub stall
+# comment. OFF BY DEFAULT because pane output can contain secrets,
+# credentials, file contents, paths, or API responses that scrolled through
+# the terminal. Enable only when you trust the repo's collaborator audience.
+python3 -m u_agents.watchdog --once --include-pane-tail
+```
+
+Default stall-comment body contains only safe metadata: tmux target, the
+unchanged-check count, and a `tmux attach` command for local inspection.
+Pane content is never posted unless `--include-pane-tail` is set; when set,
+the tail is HTML-escaped inside a `<pre>` block to neutralize Markdown
+fence-injection from captured output.
+
+State is persisted to `${XDG_STATE_HOME:-~/.local/state}/u-agents/watchdog.json`
+via an atomic `tempfile + os.replace` write, so a crash mid-write cannot
+corrupt the file. If the state file does become unreadable (manual edit,
+disk truncation), `load_state` warns and resets to empty instead of
+deadlocking the watchdog loop.
+
+Stalled-once-and-commented windows do not get re-commented until their pane
+output changes.
+
+Suggested cron entry (single check per minute):
+
+```cron
+* * * * * /usr/bin/env python3 -m u_agents.watchdog --once >> ~/Library/Logs/u-agents-watchdog.log 2>&1
+```
+
+## Scheduling under launchd (macOS)
+
+On macOS, prefer `launchd` over `cron`. Two example plists are tracked in
+`examples/launchd/`:
+
+| File | Job | Interval | Notes |
+| ---- | --- | -------- | ----- |
+| `local.u-agents.launcher.plist` | `u_agents.launcher` | 300 s (5 min) | One pass: resume sweep + claim one ready issue. |
+| `local.u-agents.watchdog.plist` | `u_agents.watchdog --once` | 60 s (1 min) | One check pass; launchd owns the cadence. |
+
+### Before installing
+
+1. **Dry-run first**, on the command line, exactly as launchd will run it.
+   Catch missing config, missing labels, or wrong python path while you can
+   read the error directly:
+
+   ```sh
+   /opt/homebrew/bin/python3 -m u_agents.launcher \
+     --config /Users/your-name/.config/u-agents/repositories.yml --dry-run
+
+   /opt/homebrew/bin/python3 -m u_agents.watchdog \
+     --config /Users/your-name/.config/u-agents/repositories.yml --once --dry-run
+   ```
+
+2. Edit the four placeholder paths in each plist:
+   - `/opt/homebrew/bin/python3` — your python interpreter
+   - `/Users/your-name/.config/u-agents/repositories.yml` — your config
+   - `/Users/your-name/dotfiles` — the dotfiles checkout (must contain `u_agents/`)
+   - `/Users/your-name/Library/Logs/u-agents-*.log` — log destination
+
+3. Make sure `PATH` in the plist includes the directories holding `gh`,
+   `tmux`, `git`, and `yq`. The examples set `/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin`.
+
+### Install / start / stop / uninstall
+
+```sh
+# Install (copies to ~/Library/LaunchAgents and registers)
+cp examples/launchd/local.u-agents.launcher.plist ~/Library/LaunchAgents/
+cp examples/launchd/local.u-agents.watchdog.plist ~/Library/LaunchAgents/
+launchctl load   ~/Library/LaunchAgents/local.u-agents.launcher.plist
+launchctl load   ~/Library/LaunchAgents/local.u-agents.watchdog.plist
+
+# Trigger one run immediately (otherwise wait for the next interval tick)
+launchctl start  local.u-agents.launcher
+launchctl start  local.u-agents.watchdog
+
+# Stop the most recent in-flight run (does NOT unload the schedule)
+launchctl stop   local.u-agents.watchdog
+
+# Inspect schedule and exit codes
+launchctl list | grep u-agents
+
+# Tail the logs
+tail -F ~/Library/Logs/u-agents-launcher.log \
+        ~/Library/Logs/u-agents-watchdog.log
+
+# Uninstall (unregister and remove)
+launchctl unload ~/Library/LaunchAgents/local.u-agents.launcher.plist
+launchctl unload ~/Library/LaunchAgents/local.u-agents.watchdog.plist
+rm ~/Library/LaunchAgents/local.u-agents.launcher.plist
+rm ~/Library/LaunchAgents/local.u-agents.watchdog.plist
+```
+
+### Why watchdog uses `--once`
+
+The watchdog also has a long-loop form (`--interval 60` without `--once`),
+but under launchd you want `--once` so:
+
+- Every tick is a fresh process; if the python process ever hangs or
+  exhausts memory, launchd will simply launch a new one next interval.
+- launchd surfaces exit codes per run (via `launchctl list`) which is more
+  useful than a single long-lived process whose internal loop is opaque.
+- Combining a python sleep loop with launchd duplicates the scheduler.
+
+For the same reason, the launcher plist uses launchd's `StartInterval`
+rather than a sleep loop in python.
+
+### Suggested intervals
+
+| Job | Interval | Rationale |
+| --- | -------- | --------- |
+| launcher | 300 s | New ready issues are rare; resume sweep is cheap but not free (one `gh issue list` per enabled repo). |
+| watchdog | 60 s | Combined with default `--stall-checks=3`, a pane must be unchanged for ~3 minutes before a ping and another ~3 minutes after a ping before a stall comment. Decrease for tighter detection, increase to save API quota. |
+
+## Workflow
+
+```
+GitHub issue with status:ready
+        │
+        ▼
+   Launcher picks one
+        │
+        ├─ swaps status:ready -> status:in-progress
+        ├─ posts claim comment with tmux/worktree/branch coords
+        ├─ ensures `agents:<window>` exists
+        └─ sends PM prompt into the window
+                │
+                ▼
+        PM (tmux pane)
+                │
+                ├─ creates/reuses worktree + branch
+                ├─ organizes requirements from the issue
+                ├─ engineer pane implements
+                ├─ reviewer pane runs review-diff
+                ├─ fix loop bounded to 3 rounds
+                └─ opens review-ready PR with `Closes #N`
+
+        Watchdog (separate loop)
+                │
+                ├─ capture-pane → hash → compare
+                ├─ N unchanged checks → tmux send-keys ping
+                └─ 2N unchanged after ping → one issue comment, then quiet
+```
+
+## What this v0.1 deliberately does not do
+
+- No Postgres / Redis / Temporal / message queues.
+- No long-running daemon.
+- No semantic memory / vector DB.
+- No multi-machine locking. Single-Launcher single-machine assumption.
+- No PR / CI / merged status labels — those are reconstructed from GitHub.
+- No automatic worktree cleanup. Cleanup happens manually after PR merge.
+
+## Verification
+
+```sh
+python3 -m unittest discover tests
+python3 -m u_agents.launcher --help
+python3 -m u_agents.watchdog --help
+python3 -m u_agents.watchdog --once --dry-run   # works without any active tmux windows
+```
+
+A live Launcher dry-run requires `gh auth login` against the configured
+repositories.

--- a/examples/launchd/local.u-agents.launcher.plist
+++ b/examples/launchd/local.u-agents.launcher.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  v0.1 launchd job for the agent Launcher.
+
+  Edit the four placeholder paths below before installing:
+    /opt/homebrew/bin/python3                            (homebrew default)
+    /Users/your-name/.config/u-agents/repositories.yml   (your config)
+    /Users/your-name/dotfiles                              (the dotfiles checkout)
+    /Users/your-name/Library/Logs/u-agents-launcher.log  (log destination)
+
+  Install:
+    cp examples/launchd/local.u-agents.launcher.plist ~/Library/LaunchAgents/
+    launchctl load   ~/Library/LaunchAgents/local.u-agents.launcher.plist
+
+  See docs/u-agents.md ("Scheduling under launchd") for the full workflow.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>local.u-agents.launcher</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/python3</string>
+        <string>-m</string>
+        <string>u_agents.launcher</string>
+        <string>--config</string>
+        <string>/Users/your-name/.config/u-agents/repositories.yml</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/your-name/dotfiles</string>
+
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/your-name/Library/Logs/u-agents-launcher.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/your-name/Library/Logs/u-agents-launcher.log</string>
+</dict>
+</plist>

--- a/examples/launchd/local.u-agents.watchdog.plist
+++ b/examples/launchd/local.u-agents.watchdog.plist
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  v0.1 launchd job for the PM Watchdog.
+
+  Uses the once flag so launchd owns the cadence. Do NOT use the long-loop
+  form here: if the python process gets stuck, launchd cannot detect a
+  stalled internal loop and the watchdog stops detecting stalls until
+  manual intervention. With the once flag, every tick is a fresh process.
+
+  Edit the four placeholder paths below before installing:
+    /opt/homebrew/bin/python3                            (homebrew default)
+    /Users/your-name/.config/u-agents/repositories.yml   (your config)
+    /Users/your-name/dotfiles                              (the dotfiles checkout)
+    /Users/your-name/Library/Logs/u-agents-watchdog.log  (log destination)
+
+  Install:
+    cp examples/launchd/local.u-agents.watchdog.plist ~/Library/LaunchAgents/
+    launchctl load   ~/Library/LaunchAgents/local.u-agents.watchdog.plist
+
+  See docs/u-agents.md ("Scheduling under launchd") for the full workflow.
+
+  Note: the include pane tail flag is NOT set here. Enable it only after
+  reading the sensitivity warning in docs/u-agents.md.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>local.u-agents.watchdog</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/python3</string>
+        <string>-m</string>
+        <string>u_agents.watchdog</string>
+        <string>--once</string>
+        <string>--config</string>
+        <string>/Users/your-name/.config/u-agents/repositories.yml</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/your-name/dotfiles</string>
+
+    <key>StartInterval</key>
+    <integer>60</integer>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/your-name/Library/Logs/u-agents-watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/your-name/Library/Logs/u-agents-watchdog.log</string>
+</dict>
+</plist>

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,0 +1,109 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from u_agents.contract import (
+    LABEL_IN_PROGRESS,
+    LABEL_READY,
+    RepoConfig,
+    branch_name,
+    load_config,
+    parse_window_name,
+    pm_pane_target,
+    tmux_window_name,
+    worktree_path,
+)
+
+
+class TestRepoConfig(unittest.TestCase):
+    def test_derived_paths(self):
+        r = RepoConfig(
+            full_name="uuta/trander-flutter",
+            workspace_root="/workspace/trander-flutter",
+            default_branch="master",
+        )
+        self.assertEqual(r.short_name, "trander-flutter")
+        self.assertEqual(r.main_checkout, "/workspace/trander-flutter/master")
+        self.assertEqual(r.worktrees_root, "/workspace/trander-flutter/.worktrees")
+
+    def test_strips_trailing_slash(self):
+        r = RepoConfig(
+            full_name="o/r",
+            workspace_root="/tmp/x/",
+            default_branch="main",
+        )
+        self.assertEqual(r.main_checkout, "/tmp/x/main")
+        self.assertEqual(r.worktrees_root, "/tmp/x/.worktrees")
+
+
+class TestNaming(unittest.TestCase):
+    def setUp(self):
+        self.repo = RepoConfig("uuta/trander-flutter", "/tmp/tf", "master")
+
+    def test_tmux_window_name(self):
+        self.assertEqual(tmux_window_name(self.repo, 233), "trander-flutter-233")
+
+    def test_pm_pane_target(self):
+        self.assertEqual(pm_pane_target("trander-flutter-233"),
+                         "agents:trander-flutter-233.0")
+
+    def test_branch_and_worktree(self):
+        self.assertEqual(branch_name(233), "feat/233")
+        self.assertEqual(worktree_path(self.repo, 233), "/tmp/tf/.worktrees/233")
+
+    def test_parse_window_name(self):
+        self.assertEqual(parse_window_name("trander-flutter-233"),
+                         ("trander-flutter", 233))
+        self.assertEqual(parse_window_name("u-5"), ("u", 5))
+        self.assertIsNone(parse_window_name("_init"))
+        self.assertIsNone(parse_window_name("misc-not-a-number"))
+
+
+class TestLoadConfig(unittest.TestCase):
+    def test_load_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "r.json"
+            p.write_text(json.dumps({
+                "repositories": [
+                    {"full_name": "o/a", "workspace_root": "/w/a",
+                     "default_branch": "main", "enabled": True},
+                    {"full_name": "o/b", "workspace_root": "/w/b",
+                     "default_branch": "master", "enabled": False},
+                ]
+            }))
+            repos = load_config(p)
+            self.assertEqual(len(repos), 2)
+            self.assertEqual(repos[0].short_name, "a")
+            self.assertFalse(repos[1].enabled)
+
+    def test_load_yaml(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "r.yml"
+            p.write_text(
+                "repositories:\n"
+                "  - full_name: o/a\n"
+                "    workspace_root: /w/a\n"
+                "    default_branch: main\n"
+                "    enabled: true\n"
+            )
+            repos = load_config(p)
+            self.assertEqual(len(repos), 1)
+            self.assertEqual(repos[0].full_name, "o/a")
+
+    def test_missing_field_raises(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "r.json"
+            p.write_text(json.dumps({"repositories": [{"full_name": "o/a"}]}))
+            with self.assertRaises(Exception):
+                load_config(p)
+
+
+class TestLabelConstants(unittest.TestCase):
+    def test_labels(self):
+        self.assertEqual(LABEL_READY, "status:ready")
+        self.assertEqual(LABEL_IN_PROGRESS, "status:in-progress")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_launchd_examples.py
+++ b/tests/test_launchd_examples.py
@@ -1,0 +1,143 @@
+"""Sanity checks for examples/launchd/*.plist.
+
+These guard against three classes of regression:
+1. Plist files must parse (otherwise `launchctl load` would fail on the user).
+2. Each plist must invoke the expected agents module.
+3. No personal paths leaked into the tracked example.
+"""
+import plistlib
+import re
+import unittest
+from pathlib import Path
+
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "examples" / "launchd"
+LAUNCHER_PLIST = EXAMPLES / "local.u-agents.launcher.plist"
+WATCHDOG_PLIST = EXAMPLES / "local.u-agents.watchdog.plist"
+
+# Patterns that must NEVER appear in a tracked example.
+PERSONAL_PATTERNS = [
+    re.compile(r"/Users/yutaaoki(?:/|$)"),
+    re.compile(r"\byutaaoki\b"),
+    re.compile(r"\buuta\b"),
+]
+
+
+def _load(path: Path) -> dict:
+    with path.open("rb") as f:
+        return plistlib.load(f)
+
+
+class TestLauncherPlist(unittest.TestCase):
+    def setUp(self):
+        self.assertTrue(LAUNCHER_PLIST.exists(), f"missing {LAUNCHER_PLIST}")
+        self.plist = _load(LAUNCHER_PLIST)
+
+    def test_label_namespaced(self):
+        self.assertEqual(self.plist["Label"], "local.u-agents.launcher")
+
+    def test_invokes_launcher_module(self):
+        args = self.plist["ProgramArguments"]
+        self.assertIn("-m", args)
+        self.assertIn("u_agents.launcher", args)
+        # python interpreter is the first arg, must be an absolute path.
+        self.assertTrue(
+            args[0].startswith("/"),
+            f"ProgramArguments[0] must be an absolute python path, got: {args[0]}",
+        )
+
+    def test_passes_config_flag(self):
+        args = self.plist["ProgramArguments"]
+        self.assertIn("--config", args)
+        idx = args.index("--config")
+        self.assertTrue(args[idx + 1].endswith("repositories.yml"),
+                        f"--config target should end with repositories.yml, got: {args[idx + 1]}")
+
+    def test_five_minute_interval(self):
+        self.assertEqual(self.plist["StartInterval"], 300)
+
+    def test_run_at_load_disabled(self):
+        # Avoid firing immediately on launchctl load.
+        self.assertFalse(self.plist.get("RunAtLoad", False))
+
+    def test_working_directory_points_at_repo_checkout(self):
+        # Required so `u_agents/` is importable.
+        self.assertIn("WorkingDirectory", self.plist)
+        self.assertTrue(self.plist["WorkingDirectory"].startswith("/"),
+                        "WorkingDirectory must be absolute")
+
+    def test_log_paths_set(self):
+        self.assertIn("StandardOutPath", self.plist)
+        self.assertIn("StandardErrorPath", self.plist)
+
+    def test_path_env_includes_homebrew(self):
+        env = self.plist.get("EnvironmentVariables", {})
+        self.assertIn("/opt/homebrew/bin", env.get("PATH", ""))
+
+
+class TestWatchdogPlist(unittest.TestCase):
+    def setUp(self):
+        self.assertTrue(WATCHDOG_PLIST.exists(), f"missing {WATCHDOG_PLIST}")
+        self.plist = _load(WATCHDOG_PLIST)
+
+    def test_label_namespaced(self):
+        self.assertEqual(self.plist["Label"], "local.u-agents.watchdog")
+
+    def test_invokes_watchdog_module(self):
+        args = self.plist["ProgramArguments"]
+        self.assertIn("-m", args)
+        self.assertIn("u_agents.watchdog", args)
+
+    def test_uses_once_flag(self):
+        # Critical: launchd must own the cadence. The long-loop form is
+        # opaque to launchd and a hung process would silently stop the
+        # watchdog. See docs/u-agents.md "Why watchdog uses --once".
+        self.assertIn("--once", self.plist["ProgramArguments"])
+
+    def test_does_not_opt_in_to_pane_tail(self):
+        # --include-pane-tail leaks pane content to GitHub. Tracked example
+        # must NOT enable it; users opt in deliberately after reading docs.
+        self.assertNotIn("--include-pane-tail", self.plist["ProgramArguments"])
+
+    def test_one_minute_interval(self):
+        self.assertEqual(self.plist["StartInterval"], 60)
+
+    def test_run_at_load_disabled(self):
+        self.assertFalse(self.plist.get("RunAtLoad", False))
+
+    def test_log_paths_set(self):
+        self.assertIn("StandardOutPath", self.plist)
+        self.assertIn("StandardErrorPath", self.plist)
+
+
+class TestNoPersonalPaths(unittest.TestCase):
+    """Fix #5 (config) reaffirmed: example plists must be free of personal data."""
+
+    def _scan(self, path: Path) -> str:
+        return path.read_text(encoding="utf-8")
+
+    def test_launcher_plist_has_no_personal_paths(self):
+        text = self._scan(LAUNCHER_PLIST)
+        for pat in PERSONAL_PATTERNS:
+            self.assertIsNone(
+                pat.search(text),
+                f"{LAUNCHER_PLIST.name} contains forbidden pattern {pat.pattern!r}",
+            )
+
+    def test_watchdog_plist_has_no_personal_paths(self):
+        text = self._scan(WATCHDOG_PLIST)
+        for pat in PERSONAL_PATTERNS:
+            self.assertIsNone(
+                pat.search(text),
+                f"{WATCHDOG_PLIST.name} contains forbidden pattern {pat.pattern!r}",
+            )
+
+    def test_examples_use_your_name_placeholder(self):
+        for path in (LAUNCHER_PLIST, WATCHDOG_PLIST):
+            text = self._scan(path)
+            self.assertIn("your-name", text,
+                          f"{path.name} should use the 'your-name' placeholder")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,513 @@
+import argparse
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from u_agents.contract import LABEL_IN_PROGRESS, LABEL_READY, RepoConfig
+from u_agents import launcher
+from u_agents.launcher import (
+    DEFAULT_PROMPT_TEMPLATE,
+    Issue,
+    classify_direct_issue,
+    dispatch_claim,
+    main as launcher_main,
+    pick_issue,
+    render_pm_prompt,
+    select_resume_targets,
+)
+
+
+def _mk_issue(repo: RepoConfig, n: int, title: str = "x",
+              labels=(LABEL_READY,)) -> Issue:
+    return Issue(repo=repo, number=n, title=title,
+                 url=f"https://github.com/{repo.full_name}/issues/{n}",
+                 labels=list(labels))
+
+
+def _args(**overrides):
+    """Build a minimal argparse.Namespace matching launcher main() args."""
+    defaults = dict(
+        config=None,
+        dry_run=False,
+        repo=None,
+        issue=None,
+        prompt_template=DEFAULT_PROMPT_TEMPLATE,
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestPickIssue(unittest.TestCase):
+    def setUp(self):
+        self.a = RepoConfig("o/a", "/w/a", "main", enabled=True)
+        self.b = RepoConfig("o/b", "/w/b", "main", enabled=True)
+        self.c = RepoConfig("o/c", "/w/c", "main", enabled=False)
+
+    def test_picks_first_enabled_with_ready(self):
+        def fake_list(r):
+            if r is self.a:
+                return []
+            if r is self.b:
+                return [_mk_issue(self.b, 7), _mk_issue(self.b, 8)]
+            return []
+        issue = pick_issue([self.a, self.b, self.c], None, None, list_fn=fake_list)
+        self.assertEqual(issue.number, 7)
+        self.assertIs(issue.repo, self.b)
+
+    def test_skips_disabled_even_with_ready(self):
+        def fake_list(r):
+            return [_mk_issue(r, 1)] if r is self.c else []
+        self.assertIsNone(pick_issue([self.c], None, None, list_fn=fake_list))
+
+    def test_repo_filter_short_name(self):
+        def fake_list(r):
+            return [_mk_issue(r, 1)]
+        issue = pick_issue([self.a, self.b], "b", None, list_fn=fake_list)
+        self.assertIs(issue.repo, self.b)
+
+    def test_repo_filter_full_name(self):
+        def fake_list(r):
+            return [_mk_issue(r, 1)]
+        issue = pick_issue([self.a, self.b], "o/a", None, list_fn=fake_list)
+        self.assertIs(issue.repo, self.a)
+
+    def test_issue_filter(self):
+        def fake_list(r):
+            return [_mk_issue(r, 1), _mk_issue(r, 42)]
+        issue = pick_issue([self.a], None, 42, list_fn=fake_list)
+        self.assertEqual(issue.number, 42)
+
+    def test_no_matches_returns_none(self):
+        def fake_list(r):
+            return []
+        self.assertIsNone(pick_issue([self.a], None, None, list_fn=fake_list))
+
+
+class TestRenderPmPrompt(unittest.TestCase):
+    def test_renders_default_template_fields(self):
+        repo = RepoConfig("uuta/trander-flutter", "/Users/y/trander-flutter", "master")
+        issue = _mk_issue(repo, 233, title="add login")
+        out = render_pm_prompt(DEFAULT_PROMPT_TEMPLATE, issue, "trander-flutter-233")
+        self.assertIn("uuta/trander-flutter#233", out)
+        self.assertIn('"add login"', out)
+        self.assertIn("agents:trander-flutter-233.0", out)
+        self.assertIn("/Users/y/trander-flutter/master", out)
+        self.assertIn("/Users/y/trander-flutter/.worktrees/233", out)
+        self.assertIn("feat/233", out)
+        # Watchdog ping line is mentioned in the contract.
+        self.assertIn("stalled", out)
+
+    def test_brace_in_title_does_not_break_format(self):
+        repo = RepoConfig("o/r", "/w/r", "main")
+        issue = _mk_issue(repo, 1, title="weird {brace} title")
+        out = render_pm_prompt(DEFAULT_PROMPT_TEMPLATE, issue, "r-1")
+        self.assertIn("weird {brace} title", out)
+
+
+class TestClaudeTmuxGuard(unittest.TestCase):
+    def setUp(self):
+        self.repo = RepoConfig("o/r", "/w/r", "main")
+        self.issue = _mk_issue(self.repo, 5, labels=[LABEL_READY])
+
+    def test_new_window_starts_claude_command(self):
+        with mock.patch("u_agents.launcher.ensure_session"), \
+             mock.patch("u_agents.launcher.window_exists", return_value=False), \
+             mock.patch("u_agents.launcher.wait_for_claude_ready") as m_wait, \
+             mock.patch("u_agents.launcher._tmux") as m_tmux:
+            window = launcher.ensure_window(self.repo, self.issue, dry_run=False)
+
+        self.assertEqual(window, "r-5")
+        m_tmux.assert_any_call([
+            "new-window", "-t", launcher.TMUX_SESSION, "-n", "r-5",
+            "-c", str(Path.home()), launcher.CLAUDE_COMMAND,
+        ])
+        m_wait.assert_called_once_with("r-5")
+
+    def test_existing_window_must_be_claude_before_prompt(self):
+        with mock.patch("u_agents.launcher.wait_for_claude_ready",
+                        side_effect=RuntimeError("not claude")), \
+             mock.patch("u_agents.launcher._tmux_in") as m_tmux_in:
+            with self.assertRaises(RuntimeError):
+                launcher.send_prompt("r-5", "hello", dry_run=False)
+        m_tmux_in.assert_not_called()
+
+    def test_wait_for_claude_ready_accepts_idle_prompt(self):
+        with mock.patch("u_agents.launcher._pane_start_command",
+                        return_value=launcher.CLAUDE_COMMAND), \
+             mock.patch("u_agents.launcher._pane_is_dead", return_value=False), \
+             mock.patch("u_agents.launcher._capture_pane",
+                        return_value="Claude Code\n\n│ >\n"):
+            launcher.wait_for_claude_ready("r-5")
+
+    def test_wait_for_claude_ready_accepts_placeholder_prompt(self):
+        with mock.patch("u_agents.launcher._pane_start_command",
+                        return_value=launcher.CLAUDE_COMMAND), \
+             mock.patch("u_agents.launcher._pane_is_dead", return_value=False), \
+             mock.patch("u_agents.launcher._capture_pane",
+                        return_value='Claude Code\n\n│ > Try "fix the tests"\n'):
+            launcher.wait_for_claude_ready("r-5")
+
+    def test_wait_for_claude_ready_accepts_current_prompt_marker(self):
+        with mock.patch("u_agents.launcher._pane_start_command",
+                        return_value=launcher.CLAUDE_COMMAND), \
+             mock.patch("u_agents.launcher._pane_is_dead", return_value=False), \
+             mock.patch("u_agents.launcher._capture_pane",
+                        return_value="Claude Code\n\n│ ❯\n"):
+            launcher.wait_for_claude_ready("r-5")
+
+    def test_wait_for_claude_ready_times_out_without_idle_prompt(self):
+        with mock.patch("u_agents.launcher._pane_start_command",
+                        return_value=launcher.CLAUDE_COMMAND), \
+             mock.patch("u_agents.launcher._pane_is_dead", return_value=False), \
+             mock.patch("u_agents.launcher._capture_pane",
+                        return_value="Claude Code update available\nPress Enter"), \
+             mock.patch("u_agents.launcher.CLAUDE_READY_TIMEOUT_SECONDS", 0.01), \
+             mock.patch("u_agents.launcher.CLAUDE_READY_POLL_SECONDS", 0), \
+             mock.patch("u_agents.launcher.time.monotonic",
+                        side_effect=[0.0, 0.0, 0.02]), \
+             mock.patch("u_agents.launcher.time.sleep"):
+            with self.assertRaisesRegex(RuntimeError, "idle input prompt"):
+                launcher.wait_for_claude_ready("r-5")
+
+    def test_send_prompt_does_not_paste_before_idle_prompt(self):
+        with mock.patch("u_agents.launcher._pane_start_command",
+                        return_value=launcher.CLAUDE_COMMAND), \
+             mock.patch("u_agents.launcher._pane_is_dead", return_value=False), \
+             mock.patch("u_agents.launcher._capture_pane",
+                        return_value="Do you trust the files in this folder?"), \
+             mock.patch("u_agents.launcher.CLAUDE_READY_TIMEOUT_SECONDS", 0.01), \
+             mock.patch("u_agents.launcher.CLAUDE_READY_POLL_SECONDS", 0), \
+             mock.patch("u_agents.launcher.time.monotonic",
+                        side_effect=[0.0, 0.0, 0.02]), \
+             mock.patch("u_agents.launcher.time.sleep"), \
+             mock.patch("u_agents.launcher._tmux_in") as m_tmux_in:
+            with self.assertRaisesRegex(RuntimeError, "idle input prompt"):
+                launcher.send_prompt("r-5", "hello", dry_run=False)
+        m_tmux_in.assert_not_called()
+
+
+class TestClaimIssue(unittest.TestCase):
+    def setUp(self):
+        self.repo = RepoConfig("o/r", "/w/r", "main")
+        self.issue = _mk_issue(self.repo, 5, labels=[LABEL_READY])
+
+    def test_unexpected_gh_edit_failure_raises(self):
+        res = mock.Mock(returncode=1, stderr="rate limit while editing labels")
+        with mock.patch("u_agents.launcher._run", return_value=res):
+            with self.assertRaisesRegex(RuntimeError, "gh issue edit failed"):
+                launcher.claim_issue(self.issue, dry_run=False)
+
+    def test_missing_label_failure_raises_with_bootstrap_hint(self):
+        res = mock.Mock(returncode=1, stderr="label not found: status:ready")
+        with mock.patch("u_agents.launcher._run", return_value=res):
+            with self.assertRaisesRegex(RuntimeError, "Create the labels"):
+                launcher.claim_issue(self.issue, dry_run=False)
+
+
+class TestClassifyDirectIssue(unittest.TestCase):
+    def setUp(self):
+        self.repo = RepoConfig("o/r", "/w/r", "main")
+
+    def test_status_ready_means_claim(self):
+        issue = _mk_issue(self.repo, 1, labels=[LABEL_READY])
+        self.assertEqual(classify_direct_issue(issue), "claim")
+
+    def test_status_in_progress_means_resume(self):
+        issue = _mk_issue(self.repo, 1, labels=[LABEL_IN_PROGRESS])
+        self.assertEqual(classify_direct_issue(issue), "resume")
+
+    def test_ready_wins_when_both_present(self):
+        # Defensive: if a repo somehow has both labels, prefer claim semantics.
+        issue = _mk_issue(self.repo, 1, labels=[LABEL_READY, LABEL_IN_PROGRESS])
+        self.assertEqual(classify_direct_issue(issue), "claim")
+
+    def test_neither_label_means_skip(self):
+        issue = _mk_issue(self.repo, 1, labels=["bug", "size:s"])
+        self.assertEqual(classify_direct_issue(issue), "skip")
+
+    def test_no_labels_means_skip(self):
+        issue = _mk_issue(self.repo, 1, labels=[])
+        self.assertEqual(classify_direct_issue(issue), "skip")
+
+
+class TestSelectResumeTargets(unittest.TestCase):
+    def setUp(self):
+        self.a = RepoConfig("o/a", "/w/a", "main", enabled=True)
+        self.b = RepoConfig("o/b", "/w/b", "main", enabled=True)
+        self.c = RepoConfig("o/c", "/w/c", "main", enabled=False)
+
+    def test_returns_only_in_progress_with_missing_window(self):
+        in_progress = {
+            self.a: [_mk_issue(self.a, 1, labels=[LABEL_IN_PROGRESS]),
+                     _mk_issue(self.a, 2, labels=[LABEL_IN_PROGRESS])],
+            self.b: [_mk_issue(self.b, 9, labels=[LABEL_IN_PROGRESS])],
+        }
+        # Only a-2 has a live window.
+        existing = {"a-2"}
+        targets = select_resume_targets(
+            [self.a, self.b],
+            list_in_progress_fn=lambda r: in_progress.get(r, []),
+            window_exists_fn=lambda w: w in existing,
+        )
+        self.assertEqual([(i.repo.full_name, i.number) for i in targets],
+                         [("o/a", 1), ("o/b", 9)])
+
+    def test_skips_disabled_repo(self):
+        in_progress = {self.c: [_mk_issue(self.c, 1, labels=[LABEL_IN_PROGRESS])]}
+        targets = select_resume_targets(
+            [self.c],
+            list_in_progress_fn=lambda r: in_progress.get(r, []),
+            window_exists_fn=lambda w: False,
+        )
+        self.assertEqual(targets, [])
+
+    def test_no_in_progress_returns_empty(self):
+        targets = select_resume_targets(
+            [self.a, self.b],
+            list_in_progress_fn=lambda r: [],
+            window_exists_fn=lambda w: False,
+        )
+        self.assertEqual(targets, [])
+
+    def test_all_windows_present_returns_empty(self):
+        in_progress = {self.a: [_mk_issue(self.a, 1, labels=[LABEL_IN_PROGRESS])]}
+        targets = select_resume_targets(
+            [self.a],
+            list_in_progress_fn=lambda r: in_progress.get(r, []),
+            window_exists_fn=lambda w: True,
+        )
+        self.assertEqual(targets, [])
+
+    def test_target_repo_filter_short_name(self):
+        in_progress = {
+            self.a: [_mk_issue(self.a, 1, labels=[LABEL_IN_PROGRESS])],
+            self.b: [_mk_issue(self.b, 2, labels=[LABEL_IN_PROGRESS])],
+        }
+        targets = select_resume_targets(
+            [self.a, self.b], target_repo="b",
+            list_in_progress_fn=lambda r: in_progress.get(r, []),
+            window_exists_fn=lambda w: False,
+        )
+        self.assertEqual([(i.repo.full_name, i.number) for i in targets],
+                         [("o/b", 2)])
+
+    def test_target_repo_filter_full_name(self):
+        in_progress = {
+            self.a: [_mk_issue(self.a, 1, labels=[LABEL_IN_PROGRESS])],
+            self.b: [_mk_issue(self.b, 2, labels=[LABEL_IN_PROGRESS])],
+        }
+        targets = select_resume_targets(
+            [self.a, self.b], target_repo="o/a",
+            list_in_progress_fn=lambda r: in_progress.get(r, []),
+            window_exists_fn=lambda w: False,
+        )
+        self.assertEqual([(i.repo.full_name, i.number) for i in targets],
+                         [("o/a", 1)])
+
+    def test_target_issue_filter_across_repos(self):
+        # Only issue #5 should be returned, even though repo b has #10 in
+        # progress with a missing window.
+        in_progress = {
+            self.a: [_mk_issue(self.a, 5, labels=[LABEL_IN_PROGRESS])],
+            self.b: [_mk_issue(self.b, 10, labels=[LABEL_IN_PROGRESS])],
+        }
+        targets = select_resume_targets(
+            [self.a, self.b], target_issue=5,
+            list_in_progress_fn=lambda r: in_progress.get(r, []),
+            window_exists_fn=lambda w: False,
+        )
+        self.assertEqual([(i.repo.full_name, i.number) for i in targets],
+                         [("o/a", 5)])
+
+    def test_target_repo_and_issue_filter(self):
+        in_progress = {
+            self.a: [_mk_issue(self.a, 5, labels=[LABEL_IN_PROGRESS]),
+                     _mk_issue(self.a, 6, labels=[LABEL_IN_PROGRESS])],
+            self.b: [_mk_issue(self.b, 5, labels=[LABEL_IN_PROGRESS])],
+        }
+        targets = select_resume_targets(
+            [self.a, self.b], target_repo="b", target_issue=5,
+            list_in_progress_fn=lambda r: in_progress.get(r, []),
+            window_exists_fn=lambda w: False,
+        )
+        self.assertEqual([(i.repo.full_name, i.number) for i in targets],
+                         [("o/b", 5)])
+
+    def test_unmatched_repo_filter_returns_empty(self):
+        in_progress = {self.a: [_mk_issue(self.a, 1, labels=[LABEL_IN_PROGRESS])]}
+        targets = select_resume_targets(
+            [self.a, self.b], target_repo="nonexistent",
+            list_in_progress_fn=lambda r: in_progress.get(r, []),
+            window_exists_fn=lambda w: False,
+        )
+        self.assertEqual(targets, [])
+
+
+class TestMainGeneralRunHonorsFilters(unittest.TestCase):
+    """End-to-end check that `python3 -m u_agents.launcher --repo X` (without
+    --issue, so direct-lookup is NOT entered) restricts the resume sweep
+    AND the claim pick to repo X only.
+    """
+
+    def setUp(self):
+        self.a = RepoConfig("o/a", "/w/a", "main", enabled=True)
+        self.b = RepoConfig("o/b", "/w/b", "main", enabled=True)
+
+    def _patched_main(self, argv, in_progress_map, ready_map):
+        """Run launcher.main with all side-effects stubbed."""
+        resumed: list[tuple[str, int]] = []
+        claimed: list[tuple[str, int]] = []
+
+        def fake_resume(issue, _args):
+            resumed.append((issue.repo.full_name, issue.number))
+            return 0
+
+        def fake_claim(issue, _args):
+            claimed.append((issue.repo.full_name, issue.number))
+            return 0
+
+        patches = [
+            mock.patch.object(launcher, "find_config", return_value=Path("/dev/null")),
+            mock.patch.object(launcher, "load_config", return_value=[self.a, self.b]),
+            mock.patch.object(launcher, "list_in_progress_issues",
+                              side_effect=lambda r: in_progress_map.get(r, [])),
+            mock.patch.object(launcher, "list_ready_issues",
+                              side_effect=lambda r: ready_map.get(r, [])),
+            mock.patch.object(launcher, "window_exists", return_value=False),
+            mock.patch.object(launcher, "dispatch_resume", side_effect=fake_resume),
+            mock.patch.object(launcher, "dispatch_claim", side_effect=fake_claim),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            launcher_main(argv)
+        finally:
+            for p in patches:
+                p.stop()
+        return resumed, claimed
+
+    def test_repo_filter_scopes_resume_sweep(self):
+        in_progress = {
+            self.a: [_mk_issue(self.a, 1, labels=[LABEL_IN_PROGRESS])],
+            self.b: [_mk_issue(self.b, 2, labels=[LABEL_IN_PROGRESS])],
+        }
+        ready = {
+            self.a: [_mk_issue(self.a, 99, labels=[LABEL_READY])],
+            self.b: [_mk_issue(self.b, 100, labels=[LABEL_READY])],
+        }
+        resumed, claimed = self._patched_main(
+            ["--repo", "a"], in_progress, ready,
+        )
+        # Resume sweep saw only repo a's in-progress; claim picked only a's ready.
+        self.assertEqual(resumed, [("o/a", 1)])
+        self.assertEqual(claimed, [("o/a", 99)])
+
+    def test_issue_filter_scopes_resume_sweep(self):
+        in_progress = {
+            self.a: [_mk_issue(self.a, 5, labels=[LABEL_IN_PROGRESS]),
+                     _mk_issue(self.a, 10, labels=[LABEL_IN_PROGRESS])],
+            self.b: [_mk_issue(self.b, 10, labels=[LABEL_IN_PROGRESS])],
+        }
+        ready = {
+            self.a: [_mk_issue(self.a, 5, labels=[LABEL_READY])],
+        }
+        resumed, claimed = self._patched_main(
+            ["--issue", "5"], in_progress, ready,
+        )
+        # Without --repo, --issue alone still scopes both phases by number 5.
+        self.assertEqual(resumed, [("o/a", 5)])
+        self.assertEqual(claimed, [("o/a", 5)])
+
+
+class TestDispatchClaimRollback(unittest.TestCase):
+    """Fix #3: rollback labels when dispatch fails after successful claim."""
+
+    def setUp(self):
+        self.repo = RepoConfig("o/r", "/w/r", "main")
+        self.issue = _mk_issue(self.repo, 5, labels=[LABEL_READY])
+
+    def test_rollback_called_when_send_prompt_fails_after_claim(self):
+        with mock.patch("u_agents.launcher.window_exists", return_value=False), \
+             mock.patch("u_agents.launcher.claim_issue", return_value=True) as m_claim, \
+             mock.patch("u_agents.launcher.ensure_window", return_value="r-5"), \
+             mock.patch("u_agents.launcher.post_claim_comment"), \
+             mock.patch("u_agents.launcher.send_prompt",
+                        side_effect=RuntimeError("tmux blew up")), \
+             mock.patch("u_agents.launcher.rollback_claim") as m_rollback:
+            with self.assertRaises(RuntimeError):
+                dispatch_claim(self.issue, _args())
+            m_claim.assert_called_once_with(self.issue, False)
+            m_rollback.assert_called_once_with(self.issue, False)
+
+    def test_cleans_new_window_when_send_prompt_fails_after_claim(self):
+        with mock.patch("u_agents.launcher.window_exists",
+                        side_effect=[False, True]) as m_exists, \
+             mock.patch("u_agents.launcher.claim_issue", return_value=True), \
+             mock.patch("u_agents.launcher.ensure_window", return_value="r-5"), \
+             mock.patch("u_agents.launcher.post_claim_comment"), \
+             mock.patch("u_agents.launcher.send_prompt",
+                        side_effect=RuntimeError("tmux blew up")), \
+             mock.patch("u_agents.launcher.rollback_claim"), \
+             mock.patch("u_agents.launcher.kill_window") as m_kill:
+            with self.assertRaises(RuntimeError):
+                dispatch_claim(self.issue, _args())
+            self.assertEqual(m_exists.call_count, 2)
+            m_kill.assert_called_once_with("r-5", False)
+
+    def test_does_not_cleanup_when_no_window_was_created(self):
+        with mock.patch("u_agents.launcher.window_exists",
+                        side_effect=[False, False]), \
+             mock.patch("u_agents.launcher.claim_issue", return_value=True), \
+             mock.patch("u_agents.launcher.ensure_window",
+                        side_effect=RuntimeError("tmux failed before create")), \
+             mock.patch("u_agents.launcher.rollback_claim"), \
+             mock.patch("u_agents.launcher.kill_window") as m_kill:
+            with self.assertRaises(RuntimeError):
+                dispatch_claim(self.issue, _args())
+            m_kill.assert_not_called()
+
+    def test_aborts_before_tmux_when_claim_swap_failed(self):
+        # If labels never swapped (claim returned False), don't dispatch.
+        with mock.patch("u_agents.launcher.window_exists", return_value=False), \
+             mock.patch("u_agents.launcher.claim_issue", return_value=False), \
+             mock.patch("u_agents.launcher.ensure_window") as m_window, \
+             mock.patch("u_agents.launcher.rollback_claim") as m_rollback:
+            rc = dispatch_claim(self.issue, _args())
+            self.assertEqual(rc, 2)
+            m_window.assert_not_called()
+            m_rollback.assert_not_called()
+
+    def test_claim_exception_aborts_before_tmux(self):
+        with mock.patch("u_agents.launcher.window_exists", return_value=False), \
+             mock.patch("u_agents.launcher.claim_issue",
+                        side_effect=RuntimeError("claim failed")), \
+             mock.patch("u_agents.launcher.ensure_window") as m_window:
+            rc = dispatch_claim(self.issue, _args())
+            self.assertEqual(rc, 2)
+            m_window.assert_not_called()
+
+    def test_no_rollback_on_clean_success(self):
+        with mock.patch("u_agents.launcher.window_exists", return_value=False), \
+             mock.patch("u_agents.launcher.claim_issue", return_value=True), \
+             mock.patch("u_agents.launcher.ensure_window", return_value="r-5"), \
+             mock.patch("u_agents.launcher.post_claim_comment"), \
+             mock.patch("u_agents.launcher.send_prompt"), \
+             mock.patch("u_agents.launcher.rollback_claim") as m_rollback:
+            rc = dispatch_claim(self.issue, _args())
+            self.assertEqual(rc, 0)
+            m_rollback.assert_not_called()
+
+    def test_existing_window_skips_dispatch_and_does_not_claim(self):
+        # If a deterministic window already exists, refuse duplicate dispatch
+        # and DO NOT swap labels.
+        with mock.patch("u_agents.launcher.window_exists", return_value=True), \
+             mock.patch("u_agents.launcher.claim_issue") as m_claim, \
+             mock.patch("u_agents.launcher.send_prompt") as m_send:
+            rc = dispatch_claim(self.issue, _args())
+            self.assertEqual(rc, 0)
+            m_claim.assert_not_called()
+            m_send.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -204,6 +204,19 @@ class TestClaimIssue(unittest.TestCase):
                 launcher.claim_issue(self.issue, dry_run=False)
 
 
+class TestListByLabel(unittest.TestCase):
+    def test_malformed_json_returns_empty_and_warns(self):
+        repo = RepoConfig("o/r", "/w/r", "main")
+        res = mock.Mock(returncode=0, stdout="{not json", stderr="")
+        with mock.patch("u_agents.launcher._run", return_value=res), \
+             mock.patch("sys.stderr") as stderr:
+            self.assertEqual(launcher._list_by_label(repo, LABEL_READY), [])
+
+        warning = "".join(call.args[0] for call in stderr.write.call_args_list)
+        self.assertIn("WARN: gh issue list returned malformed JSON", warning)
+        self.assertIn("o/r", warning)
+
+
 class TestClassifyDirectIssue(unittest.TestCase):
     def setUp(self):
         self.repo = RepoConfig("o/r", "/w/r", "main")

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -270,6 +270,34 @@ class TestLoadStateCorruption(unittest.TestCase):
             again = load_state(f)
             self.assertEqual(again["u-9"].last_hash, "h")
 
+    def test_root_not_dict_returns_empty(self):
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "w.json"
+            f.write_text('["u-5"]', encoding="utf-8")
+            self.assertEqual(load_state(f), {})
+
+    def test_value_not_dict_is_skipped(self):
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "w.json"
+            f.write_text(
+                '{"u-5": {"last_hash": "ok"}, "u-6": "bad"}',
+                encoding="utf-8",
+            )
+            state = load_state(f)
+            self.assertEqual(sorted(state), ["u-5"])
+            self.assertEqual(state["u-5"].last_hash, "ok")
+
+    def test_unknown_fields_are_ignored(self):
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "w.json"
+            f.write_text(
+                '{"u-5": {"last_hash": "ok", "future_field": "kept out"}}',
+                encoding="utf-8",
+            )
+            state = load_state(f)
+            self.assertEqual(state["u-5"].last_hash, "ok")
+            self.assertFalse(hasattr(state["u-5"], "future_field"))
+
 
 class TestAtomicSaveState(unittest.TestCase):
     """Fix #4: save_state must be atomic and not leave temp files behind."""

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,309 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from u_agents.contract import RepoConfig
+from u_agents.watchdog import (
+    WindowState,
+    build_stall_comment_body,
+    check_once,
+    load_state,
+    save_state,
+)
+
+
+class FakeClock:
+    def __init__(self):
+        self.t = 1000.0
+
+    def __call__(self):
+        self.t += 1.0
+        return self.t
+
+
+class TestStateRoundtrip(unittest.TestCase):
+    def test_save_and_load(self):
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "w.json"
+            state = {
+                "u-5": WindowState(last_hash="abc", unchanged_checks=2,
+                                   pinged=True, stall_comment_posted=False,
+                                   last_update=123.0),
+            }
+            save_state(f, state)
+            got = load_state(f)
+            self.assertEqual(got["u-5"].last_hash, "abc")
+            self.assertEqual(got["u-5"].unchanged_checks, 2)
+            self.assertTrue(got["u-5"].pinged)
+
+
+class TestCheckOnce(unittest.TestCase):
+    def setUp(self):
+        self.repo = RepoConfig("uuta/u", "/Users/y/u", "main")
+        self.window = "u-5"
+        self.tmp = tempfile.TemporaryDirectory()
+        self.state_file = Path(self.tmp.name) / "w.json"
+        self.captures = []  # list of (call_index -> text)
+        self.pings = []
+        self.comments = []
+        self.clock = FakeClock()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run(self, capture_text):
+        def list_windows():
+            return [self.window]
+        def capture(w):
+            self.assertEqual(w, self.window)
+            return capture_text
+        def ping(w, dry):
+            self.pings.append(w)
+        def comment(repo_full, num, w, text, unchanged, dry):
+            self.comments.append((repo_full, num, w, unchanged))
+        return check_once(
+            [self.repo], self.state_file, stall_checks=2, dry_run=False,
+            list_windows=list_windows, capture=capture, ping=ping,
+            comment=comment, now=self.clock,
+        )
+
+    def test_changing_output_never_pings(self):
+        self._run("frame 1")
+        self._run("frame 2")
+        self._run("frame 3")
+        self.assertEqual(self.pings, [])
+        self.assertEqual(self.comments, [])
+
+    def test_pings_after_stall_threshold(self):
+        # first call seeds the hash (unchanged_checks=0)
+        self._run("idle")
+        # second: matches -> unchanged_checks=1, no ping (threshold=2)
+        self._run("idle")
+        self.assertEqual(self.pings, [])
+        # third: matches -> unchanged_checks=2, ping fires
+        self._run("idle")
+        self.assertEqual(self.pings, [self.window])
+        self.assertEqual(self.comments, [])
+
+    def test_comments_after_ping_and_continued_stall(self):
+        # seed
+        self._run("idle")
+        # reach ping at threshold=2
+        self._run("idle")
+        self._run("idle")
+        self.assertEqual(self.pings, [self.window])
+        # need unchanged_checks >= stall_checks*2 = 4 to comment
+        self._run("idle")  # 3
+        self.assertEqual(self.comments, [])
+        self._run("idle")  # 4 -> comment
+        self.assertEqual(self.comments, [("uuta/u", 5, self.window, 4)])
+        # subsequent stalls do not re-comment
+        self._run("idle")
+        self.assertEqual(len(self.comments), 1)
+
+    def test_change_resets_state(self):
+        self._run("a")
+        self._run("a")
+        self._run("a")  # pinged
+        self.assertEqual(self.pings, [self.window])
+        self._run("b")  # change -> reset
+        st = load_state(self.state_file)[self.window]
+        self.assertEqual(st.unchanged_checks, 0)
+        self.assertFalse(st.pinged)
+        self.assertFalse(st.stall_comment_posted)
+
+    def test_removes_gone_windows(self):
+        # seed with a stale entry
+        seed = {"gone-1": WindowState(last_hash="x", unchanged_checks=1,
+                                       last_update=10.0)}
+        save_state(self.state_file, seed)
+        self._run("idle")
+        state = load_state(self.state_file)
+        self.assertNotIn("gone-1", state)
+        self.assertIn(self.window, state)
+
+    def test_ping_failure_is_persisted_and_not_retried_next_tick(self):
+        attempts = []
+
+        def list_windows():
+            return [self.window]
+
+        def capture(_w):
+            return "idle"
+
+        def ping(w, _dry):
+            attempts.append(w)
+            raise RuntimeError("pane gone")
+
+        def comment(*_args):
+            pass
+
+        # seed, then reach the ping threshold
+        check_once(
+            [self.repo], self.state_file, stall_checks=2, dry_run=False,
+            list_windows=list_windows, capture=capture, ping=ping,
+            comment=comment, now=self.clock,
+        )
+        check_once(
+            [self.repo], self.state_file, stall_checks=2, dry_run=False,
+            list_windows=list_windows, capture=capture, ping=ping,
+            comment=comment, now=self.clock,
+        )
+        check_once(
+            [self.repo], self.state_file, stall_checks=2, dry_run=False,
+            list_windows=list_windows, capture=capture, ping=ping,
+            comment=comment, now=self.clock,
+        )
+
+        self.assertEqual(attempts, [self.window])
+        self.assertTrue(load_state(self.state_file)[self.window].pinged)
+
+        # Next launchd-style tick sees pinged=True and does not retry.
+        check_once(
+            [self.repo], self.state_file, stall_checks=2, dry_run=False,
+            list_windows=list_windows, capture=capture, ping=ping,
+            comment=comment, now=self.clock,
+        )
+        self.assertEqual(attempts, [self.window])
+
+
+class TestCheckOnceUnknownRepo(unittest.TestCase):
+    def test_unresolvable_window_skips_comment(self):
+        repo = RepoConfig("o/known", "/w", "main")
+        with tempfile.TemporaryDirectory() as d:
+            sf = Path(d) / "w.json"
+            comments = []
+            def list_windows():
+                return ["unknown-9"]
+            text = "idle"
+            def capture(w):
+                return text
+            def ping(w, dry):
+                pass
+            def comment(*a):
+                comments.append(a)
+            for _ in range(6):
+                check_once(
+                    [repo], sf, stall_checks=2, dry_run=False,
+                    list_windows=list_windows, capture=capture, ping=ping,
+                    comment=comment, now=lambda: 1.0,
+                )
+            self.assertEqual(comments, [])
+
+
+class TestStallCommentBody(unittest.TestCase):
+    """Fix #2: default comment body must not leak captured pane content."""
+
+    def test_default_body_excludes_pane_tail(self):
+        capture = (
+            "secret_token=ABC123XYZ\n"
+            "/Users/secret/path/file.py\n"
+            "Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig\n"
+        )
+        body = build_stall_comment_body("u-5", capture, unchanged_checks=6)
+        self.assertNotIn("ABC123XYZ", body)
+        self.assertNotIn("/Users/secret", body)
+        self.assertNotIn("Bearer", body)
+        self.assertNotIn("eyJhbGciOiJIUzI1NiJ9", body)
+        self.assertNotIn("<details>", body)
+        # But operator-useful metadata is present.
+        self.assertIn("agents:u-5.0", body)
+        self.assertIn("unchanged-check count: 6", body)
+        self.assertIn("tmux attach", body)
+        self.assertIn("u-5", body)
+
+    def test_default_body_documents_intentional_omission(self):
+        body = build_stall_comment_body("u-5", "anything", unchanged_checks=4)
+        self.assertIn("intentionally not posted", body)
+
+    def test_opt_in_body_includes_sanitized_tail(self):
+        capture = "line 1\nline 2 has <tag> & ampersand\n```\nfake fence\n```\n"
+        body = build_stall_comment_body(
+            "u-5", capture, unchanged_checks=4, include_tail=True,
+        )
+        self.assertIn("<details>", body)
+        self.assertIn("sensitive", body.lower())
+        # HTML-escaped to prevent breaking out of <pre>.
+        self.assertIn("&lt;tag&gt;", body)
+        self.assertIn("&amp; ampersand", body)
+        # Original raw < and unescaped ``` could only be hostile if literally
+        # present; they shouldn't be in the comment unescaped.
+        self.assertNotIn("<tag>", body)
+        # The literal backticks are allowed inside <pre> (they don't break out),
+        # but the <pre> wrapper itself must be present so they render verbatim.
+        self.assertIn("<pre>", body)
+        self.assertIn("</pre>", body)
+
+
+class TestLoadStateCorruption(unittest.TestCase):
+    """Fix #4: load_state must not raise on corrupted JSON."""
+
+    def test_corrupted_json_returns_empty_and_warns(self):
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "w.json"
+            f.write_text("{not valid json", encoding="utf-8")
+            # Should not raise.
+            state = load_state(f)
+            self.assertEqual(state, {})
+
+    def test_truncated_file_returns_empty(self):
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "w.json"
+            f.write_text('{"u-5": {"last_hash": "ab', encoding="utf-8")
+            self.assertEqual(load_state(f), {})
+
+    def test_empty_file_returns_empty(self):
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "w.json"
+            f.write_text("", encoding="utf-8")
+            self.assertEqual(load_state(f), {})
+
+    def test_after_corruption_save_overwrites_cleanly(self):
+        # End-to-end recovery: corruption → load returns {} → save writes
+        # valid JSON that subsequent load reads correctly.
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "w.json"
+            f.write_text("garbage", encoding="utf-8")
+            self.assertEqual(load_state(f), {})
+            save_state(f, {"u-9": WindowState(last_hash="h", unchanged_checks=1)})
+            again = load_state(f)
+            self.assertEqual(again["u-9"].last_hash, "h")
+
+
+class TestAtomicSaveState(unittest.TestCase):
+    """Fix #4: save_state must be atomic and not leave temp files behind."""
+
+    def test_no_temp_files_remain_after_save(self):
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "w.json"
+            save_state(f, {"u-1": WindowState(last_hash="x")})
+            entries = sorted(p.name for p in Path(d).iterdir())
+            self.assertEqual(entries, ["w.json"])
+
+    def test_save_does_not_corrupt_existing_state_when_payload_fails(self):
+        # If something in the payload is unserializable, the old file must
+        # remain intact. We simulate by trying to save a non-dataclass value,
+        # which raises before os.replace.
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "w.json"
+            save_state(f, {"u-1": WindowState(last_hash="original")})
+            before = f.read_text(encoding="utf-8")
+            with self.assertRaises(TypeError):
+                # asdict() will fail on a non-dataclass object
+                save_state(f, {"u-1": object()})  # type: ignore[arg-type]
+            after = f.read_text(encoding="utf-8")
+            self.assertEqual(before, after)
+            # And no .tmp leftovers polluting the dir.
+            entries = sorted(p.name for p in Path(d).iterdir())
+            self.assertEqual(entries, ["w.json"])
+
+    def test_save_in_nonexistent_parent_creates_it(self):
+        with tempfile.TemporaryDirectory() as d:
+            f = Path(d) / "nested" / "deep" / "w.json"
+            save_state(f, {"u-1": WindowState(last_hash="x")})
+            self.assertTrue(f.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/u_agents/README.md
+++ b/u_agents/README.md
@@ -1,0 +1,17 @@
+# u_agents/
+
+v0.1 local agent runner. See [`docs/u-agents.md`](../docs/u-agents.md) for the
+full design, configuration, and command reference.
+
+Layout:
+
+- `contract.py` — config + naming primitives.
+- `launcher.py` — short-lived starter/resumer (`python3 -m u_agents.launcher`).
+- `watchdog.py` — stall detector (`python3 -m u_agents.watchdog`).
+- `prompts/pm.md` — PM prompt template sent into the tmux PM pane.
+
+Tests live under `../tests/`. Run with:
+
+```sh
+python3 -m unittest discover tests
+```

--- a/u_agents/__init__.py
+++ b/u_agents/__init__.py
@@ -1,0 +1,1 @@
+"""v0.1 local agent runner: Launcher, PM prompt, Watchdog."""

--- a/u_agents/contract.py
+++ b/u_agents/contract.py
@@ -1,0 +1,121 @@
+"""Shared types and naming contract for the v0.1 agent runner.
+
+Naming is deterministic so Launcher and Watchdog reconstruct the same names
+from a (repo, issue_number) pair without needing an ops DB.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+
+TMUX_SESSION = "agents"
+LABEL_READY = "status:ready"
+LABEL_IN_PROGRESS = "status:in-progress"
+
+_WINDOW_RE = re.compile(r"^(?P<repo>[A-Za-z0-9._-]+)-(?P<num>\d+)$")
+
+
+@dataclass(frozen=True)
+class RepoConfig:
+    full_name: str
+    workspace_root: str
+    default_branch: str
+    enabled: bool = True
+
+    @property
+    def short_name(self) -> str:
+        return self.full_name.split("/", 1)[-1]
+
+    @property
+    def main_checkout(self) -> str:
+        return f"{self.workspace_root.rstrip('/')}/{self.default_branch}"
+
+    @property
+    def worktrees_root(self) -> str:
+        return f"{self.workspace_root.rstrip('/')}/.worktrees"
+
+
+class ConfigError(ValueError):
+    pass
+
+
+def load_config(path: Path) -> List[RepoConfig]:
+    """Load a repositories config (YAML via external yq, or JSON)."""
+    text = path.read_text(encoding="utf-8")
+    suffix = path.suffix.lower()
+    if suffix in (".yml", ".yaml"):
+        data = _yaml_to_dict(text, path)
+    elif suffix == ".json":
+        data = json.loads(text)
+    else:
+        raise ConfigError(f"Unsupported config extension: {path.suffix}")
+
+    repos_raw = data.get("repositories") if isinstance(data, dict) else None
+    if not isinstance(repos_raw, list):
+        raise ConfigError(f"Config missing 'repositories' list: {path}")
+
+    out: List[RepoConfig] = []
+    for i, r in enumerate(repos_raw):
+        if not isinstance(r, dict):
+            raise ConfigError(f"repositories[{i}] must be a mapping")
+        for field in ("full_name", "workspace_root", "default_branch"):
+            if field not in r:
+                raise ConfigError(f"repositories[{i}] missing required field: {field}")
+        out.append(
+            RepoConfig(
+                full_name=str(r["full_name"]),
+                workspace_root=str(r["workspace_root"]),
+                default_branch=str(r["default_branch"]),
+                enabled=bool(r.get("enabled", True)),
+            )
+        )
+    return out
+
+
+def _yaml_to_dict(text: str, path: Path) -> dict:
+    if shutil.which("yq") is None:
+        raise ConfigError(
+            "yq is required to parse YAML config; install MikeFarah yq or use a .json config"
+        )
+    res = subprocess.run(
+        ["yq", "-o=json", "."],
+        input=text,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if res.returncode != 0:
+        raise ConfigError(f"yq failed for {path}: {res.stderr.strip()}")
+    return json.loads(res.stdout or "{}")
+
+
+# Naming helpers -----------------------------------------------------------
+
+def tmux_window_name(repo: RepoConfig, issue_number: int) -> str:
+    return f"{repo.short_name}-{issue_number}"
+
+
+def pm_pane_target(window: str) -> str:
+    return f"{TMUX_SESSION}:{window}.0"
+
+
+def branch_name(issue_number: int) -> str:
+    return f"feat/{issue_number}"
+
+
+def worktree_path(repo: RepoConfig, issue_number: int) -> str:
+    return f"{repo.worktrees_root}/{issue_number}"
+
+
+def parse_window_name(window: str) -> tuple[str, int] | None:
+    """Parse a deterministic window name back into (repo_short, issue_number)."""
+    m = _WINDOW_RE.match(window)
+    if not m:
+        return None
+    return m.group("repo"), int(m.group("num"))

--- a/u_agents/launcher.py
+++ b/u_agents/launcher.py
@@ -1,0 +1,731 @@
+#!/usr/bin/env python3
+"""v0.1 Launcher: short-lived starter/resumer for tmux PM agents.
+
+Picks one status:ready issue from an enabled target repository, claims it
+by swapping labels and posting a claim comment, ensures a deterministic
+tmux window exists, and sends the PM prompt into that window.
+
+Read-only on GitHub by default; --dry-run additionally suppresses tmux
+writes and claim mutations. GitHub authentication is required for issue
+listing in both modes.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Optional
+
+from u_agents.contract import (
+    LABEL_IN_PROGRESS,
+    LABEL_READY,
+    RepoConfig,
+    TMUX_SESSION,
+    branch_name,
+    load_config,
+    pm_pane_target,
+    tmux_window_name,
+    worktree_path,
+)
+
+DEFAULT_CONFIG_PATHS = [
+    Path("config/repositories.yml"),
+    Path("config/repositories.yaml"),
+    Path.home() / ".config" / "u-agents" / "repositories.yml",
+    Path.home() / ".config" / "u-agents" / "repositories.yaml",
+]
+
+DEFAULT_PROMPT_TEMPLATE = Path(__file__).parent / "prompts" / "pm.md"
+CLAUDE_COMMAND = os.environ.get("U_AGENTS_CLAUDE_COMMAND", "claude")
+CLAUDE_READY_TIMEOUT_SECONDS = 10.0
+CLAUDE_READY_POLL_SECONDS = 0.25
+CLAUDE_READY_RE = re.compile(r"^\s*(?:[│|]\s*)?[>❯]\s*(?:$|Try\b)")
+
+
+@dataclass
+class Issue:
+    repo: RepoConfig
+    number: int
+    title: str
+    url: str
+    labels: List[str]
+
+
+# ---------------------------------------------------------------------------
+# Config discovery
+# ---------------------------------------------------------------------------
+
+def find_config(explicit: Optional[Path]) -> Path:
+    if explicit is not None:
+        if not explicit.exists():
+            raise FileNotFoundError(f"Config not found: {explicit}")
+        return explicit
+    for p in DEFAULT_CONFIG_PATHS:
+        if p.exists():
+            return p
+    raise FileNotFoundError(
+        "No config found. Pass --config or create one at "
+        + " or ".join(str(p) for p in DEFAULT_CONFIG_PATHS)
+    )
+
+
+# ---------------------------------------------------------------------------
+# GitHub
+# ---------------------------------------------------------------------------
+
+def _run(cmd: List[str], **kw) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+
+def _list_by_label(repo: RepoConfig, label: str) -> List[Issue]:
+    res = _run(
+        [
+            "gh", "issue", "list",
+            "--repo", repo.full_name,
+            "--label", label,
+            "--state", "open",
+            "--json", "number,title,url,labels",
+            "--limit", "50",
+        ]
+    )
+    if res.returncode != 0:
+        msg = (res.stderr or "").strip()
+        print(f"WARN: gh issue list failed for {repo.full_name}: {msg}", file=sys.stderr)
+        return []
+    if not res.stdout.strip():
+        return []
+    data = json.loads(res.stdout)
+    out: List[Issue] = []
+    for it in data:
+        labels = [l.get("name", "") for l in it.get("labels", [])]
+        out.append(
+            Issue(
+                repo=repo,
+                number=int(it["number"]),
+                title=str(it.get("title", "")),
+                url=str(it.get("url", "")),
+                labels=labels,
+            )
+        )
+    return out
+
+
+def list_ready_issues(repo: RepoConfig) -> List[Issue]:
+    return _list_by_label(repo, LABEL_READY)
+
+
+def list_in_progress_issues(repo: RepoConfig) -> List[Issue]:
+    return _list_by_label(repo, LABEL_IN_PROGRESS)
+
+
+def fetch_issue(repo: RepoConfig, number: int) -> Optional[Issue]:
+    """Direct lookup of a specific issue regardless of label.
+
+    Returns None if the issue cannot be fetched or is not OPEN.
+    """
+    res = _run(
+        [
+            "gh", "issue", "view", str(number),
+            "--repo", repo.full_name,
+            "--json", "number,title,url,labels,state",
+        ]
+    )
+    if res.returncode != 0:
+        print(
+            f"WARN: gh issue view failed for {repo.full_name}#{number}: "
+            f"{(res.stderr or '').strip()}",
+            file=sys.stderr,
+        )
+        return None
+    try:
+        data = json.loads(res.stdout)
+    except json.JSONDecodeError as e:
+        print(
+            f"WARN: gh issue view returned malformed JSON for "
+            f"{repo.full_name}#{number}: {e}",
+            file=sys.stderr,
+        )
+        return None
+    state = data.get("state", "OPEN")
+    if state != "OPEN":
+        print(
+            f"SKIP: {repo.full_name}#{number} is {state}; refusing to dispatch",
+            file=sys.stderr,
+        )
+        return None
+    labels = [l.get("name", "") for l in data.get("labels", [])]
+    return Issue(
+        repo=repo,
+        number=int(data["number"]),
+        title=str(data.get("title", "")),
+        url=str(data.get("url", "")),
+        labels=labels,
+    )
+
+
+def rollback_claim(issue: Issue, dry_run: bool) -> bool:
+    """Revert a claim: status:in-progress -> status:ready.
+
+    Used when dispatch fails after a successful label swap so the issue
+    re-enters the queue. If this also fails, the resume path will recover
+    the issue on the next launcher run.
+    """
+    if dry_run:
+        print(
+            f"DRY: would rollback labels to {LABEL_READY!r} on "
+            f"{issue.repo.full_name}#{issue.number}",
+            file=sys.stderr,
+        )
+        return True
+    res = _run(
+        [
+            "gh", "issue", "edit", str(issue.number),
+            "--repo", issue.repo.full_name,
+            "--add-label", LABEL_READY,
+            "--remove-label", LABEL_IN_PROGRESS,
+        ]
+    )
+    if res.returncode != 0:
+        print(
+            f"WARN: label rollback failed for {issue.repo.full_name}#{issue.number}: "
+            f"{(res.stderr or '').strip()}\n"
+            f"      Recovery: re-run the launcher; the in-progress resume path will\n"
+            f"      recreate the PM window. Or manually swap labels back.",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def claim_issue(issue: Issue, dry_run: bool) -> bool:
+    """Swap status:ready -> status:in-progress.
+
+    A failed claim is unsafe to dispatch because the issue may still be
+    visible as status:ready to the next launcher run. Abort instead.
+    """
+    if dry_run:
+        print(
+            f"DRY: would add label {LABEL_IN_PROGRESS!r} and remove {LABEL_READY!r} "
+            f"on {issue.repo.full_name}#{issue.number}",
+            file=sys.stderr,
+        )
+        return True
+    res = _run(
+        [
+            "gh", "issue", "edit", str(issue.number),
+            "--repo", issue.repo.full_name,
+            "--add-label", LABEL_IN_PROGRESS,
+            "--remove-label", LABEL_READY,
+        ]
+    )
+    if res.returncode != 0:
+        stderr = (res.stderr or "").strip()
+        lower = stderr.lower()
+        if (
+            "label not found" in lower
+            or "not found" in lower and "label" in lower
+            or "could not add" in lower and "label" in lower
+        ):
+            raise RuntimeError(
+                f"label swap failed for {issue.repo.full_name}#{issue.number}: "
+                f"{stderr}\n"
+                f"Create the labels '{LABEL_READY}' and '{LABEL_IN_PROGRESS}' "
+                f"on that repo, then re-run the launcher."
+            )
+        raise RuntimeError(
+            f"gh issue edit failed for {issue.repo.full_name}#{issue.number}: {stderr}"
+        )
+    return True
+
+
+def post_claim_comment(issue: Issue, window: str, dry_run: bool) -> None:
+    body = (
+        "Agent claim:\n"
+        f"- tmux session: {TMUX_SESSION}\n"
+        f"- tmux window: {window}\n"
+        f"- pm pane: {pm_pane_target(window)}\n"
+        f"- worktree: .worktrees/{issue.number}\n"
+        f"- branch: {branch_name(issue.number)}\n"
+        f"- pr: <empty until opened>\n"
+    )
+    if dry_run:
+        print(
+            f"DRY: would comment on {issue.repo.full_name}#{issue.number}:\n{body}",
+            file=sys.stderr,
+        )
+        return
+    res = _run(
+        [
+            "gh", "issue", "comment", str(issue.number),
+            "--repo", issue.repo.full_name,
+            "--body", body,
+        ]
+    )
+    if res.returncode != 0:
+        print(
+            f"WARN: claim comment failed for {issue.repo.full_name}#{issue.number}: "
+            f"{res.stderr.strip()}",
+            file=sys.stderr,
+        )
+
+
+# ---------------------------------------------------------------------------
+# tmux
+# ---------------------------------------------------------------------------
+
+def _tmux(args: List[str], check: bool = True) -> subprocess.CompletedProcess:
+    return _run(["tmux", *args], check=check)
+
+
+def ensure_session() -> None:
+    res = _tmux(["has-session", "-t", TMUX_SESSION], check=False)
+    if res.returncode != 0:
+        _tmux(["new-session", "-d", "-s", TMUX_SESSION, "-n", "_init"])
+
+
+def window_exists(window: str) -> bool:
+    res = _tmux(
+        ["list-windows", "-t", TMUX_SESSION, "-F", "#{window_name}"],
+        check=False,
+    )
+    if res.returncode != 0:
+        return False
+    return window in res.stdout.splitlines()
+
+
+def kill_window(window: str, dry_run: bool) -> bool:
+    if dry_run:
+        print(f"DRY: would kill tmux window {TMUX_SESSION}:{window}", file=sys.stderr)
+        return True
+    res = _tmux(["kill-window", "-t", f"{TMUX_SESSION}:{window}"], check=False)
+    if res.returncode != 0:
+        print(
+            f"WARN: failed to kill tmux window {TMUX_SESSION}:{window}: "
+            f"{(res.stderr or '').strip()}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def ensure_window(repo: RepoConfig, issue: Issue, dry_run: bool) -> str:
+    window = tmux_window_name(repo, issue.number)
+    if dry_run:
+        print(
+            f"DRY: would ensure tmux window {window} running {CLAUDE_COMMAND!r}",
+            file=sys.stderr,
+        )
+        return window
+    ensure_session()
+    if window_exists(window):
+        wait_for_claude_ready(window)
+        return window
+    cwd = repo.main_checkout if Path(repo.main_checkout).is_dir() else repo.workspace_root
+    if not Path(cwd).is_dir():
+        cwd = str(Path.home())
+    _tmux(["new-window", "-t", TMUX_SESSION, "-n", window, "-c", cwd, CLAUDE_COMMAND])
+    _tmux(["select-pane", "-T", "pm", "-t", pm_pane_target(window)], check=False)
+    wait_for_claude_ready(window)
+    return window
+
+
+def _command_name(command: str) -> str:
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        parts = command.split()
+    if not parts:
+        return ""
+    return Path(parts[0]).name
+
+
+def _is_expected_claude_start(command: str) -> bool:
+    return _command_name(command) == _command_name(CLAUDE_COMMAND)
+
+
+def _pane_start_command(window: str) -> Optional[str]:
+    res = _tmux(
+        ["display-message", "-p", "-t", pm_pane_target(window), "#{pane_start_command}"],
+        check=False,
+    )
+    if res.returncode != 0:
+        return None
+    return res.stdout.strip()
+
+
+def _pane_is_dead(window: str) -> bool:
+    res = _tmux(
+        ["display-message", "-p", "-t", pm_pane_target(window), "#{pane_dead}"],
+        check=False,
+    )
+    if res.returncode != 0:
+        return True
+    return res.stdout.strip() == "1"
+
+
+def _capture_pane(window: str) -> str:
+    res = _tmux(["capture-pane", "-p", "-t", pm_pane_target(window)], check=False)
+    if res.returncode != 0:
+        return ""
+    return res.stdout
+
+
+def _claude_appears_ready(capture: str) -> bool:
+    return any(CLAUDE_READY_RE.search(line) for line in capture.splitlines()[-8:])
+
+
+def wait_for_claude_ready(window: str) -> None:
+    """Verify prompt delivery would target an idle Claude Code prompt."""
+    deadline = time.monotonic() + CLAUDE_READY_TIMEOUT_SECONDS
+    last_start: Optional[str] = None
+    saw_claude_process = False
+    while time.monotonic() < deadline:
+        start = _pane_start_command(window)
+        dead = _pane_is_dead(window)
+        if start is not None:
+            last_start = start
+            if _is_expected_claude_start(start) and not dead:
+                saw_claude_process = True
+                if _claude_appears_ready(_capture_pane(window)):
+                    return
+            elif start and not _is_expected_claude_start(start):
+                raise RuntimeError(
+                    f"tmux pane {pm_pane_target(window)} was started by "
+                    f"{start!r}, not {CLAUDE_COMMAND!r}; refusing to send PM prompt"
+                )
+            elif dead:
+                raise RuntimeError(
+                    f"tmux pane {pm_pane_target(window)} is dead; "
+                    f"refusing to send PM prompt"
+                )
+        time.sleep(CLAUDE_READY_POLL_SECONDS)
+    if saw_claude_process:
+        raise RuntimeError(
+            f"Claude Code pane {pm_pane_target(window)} did not show an idle "
+            f"input prompt before timeout; refusing to send PM prompt"
+        )
+    detail = "<missing pane>" if last_start is None else repr(last_start)
+    raise RuntimeError(
+        f"tmux pane {pm_pane_target(window)} is not a ready Claude Code pane "
+        f"(start command: {detail}); refusing to send PM prompt"
+    )
+
+
+def send_prompt(window: str, prompt: str, dry_run: bool) -> None:
+    pane = pm_pane_target(window)
+    if dry_run:
+        print(f"DRY: would send prompt to {pane}:\n----\n{prompt}\n----",
+              file=sys.stderr)
+        return
+    wait_for_claude_ready(window)
+    buf = f"u-agent-prompt-{os.getpid()}"
+    _tmux_in(["tmux", "load-buffer", "-b", buf, "-"], prompt)
+    try:
+        _tmux(["paste-buffer", "-b", buf, "-t", pane])
+        _tmux(["send-keys", "-t", pane, "Enter"])
+    finally:
+        _tmux(["delete-buffer", "-b", buf], check=False)
+
+
+def _tmux_in(cmd: List[str], data: str) -> None:
+    res = subprocess.run(cmd, input=data, text=True, capture_output=True, check=False)
+    if res.returncode != 0:
+        raise RuntimeError(f"{' '.join(cmd)} failed: {res.stderr.strip()}")
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+def pick_issue(
+    repos: List[RepoConfig],
+    target_repo: Optional[str],
+    target_issue: Optional[int],
+    list_fn: Optional[Callable[[RepoConfig], List[Issue]]] = None,
+) -> Optional[Issue]:
+    # Late-bound so monkey-patching list_ready_issues at the module level is honored.
+    if list_fn is None:
+        list_fn = list_ready_issues
+    for repo in repos:
+        if not repo.enabled:
+            continue
+        if target_repo and repo.full_name != target_repo and repo.short_name != target_repo:
+            continue
+        for issue in list_fn(repo):
+            if target_issue is None or issue.number == target_issue:
+                return issue
+    return None
+
+
+_PLACEHOLDER_RE = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
+
+
+def render_pm_prompt(template_path: Path, issue: Issue, window: str) -> str:
+    repo = issue.repo
+    mapping = {
+        "repo_full": repo.full_name,
+        "repo_short": repo.short_name,
+        "workspace_root": repo.workspace_root,
+        "default_branch": repo.default_branch,
+        "main_checkout": repo.main_checkout,
+        "worktrees_root": repo.worktrees_root,
+        "worktree": worktree_path(repo, issue.number),
+        "branch": branch_name(issue.number),
+        "issue_number": str(issue.number),
+        "issue_title": issue.title,
+        "issue_url": issue.url,
+        "tmux_session": TMUX_SESSION,
+        "tmux_window": window,
+        "pm_pane": pm_pane_target(window),
+    }
+    tmpl = template_path.read_text(encoding="utf-8")
+
+    def repl(m: re.Match) -> str:
+        key = m.group(1)
+        if key not in mapping:
+            raise KeyError(f"Unknown placeholder {{{key}}} in {template_path}")
+        return mapping[key]
+
+    return _PLACEHOLDER_RE.sub(repl, tmpl)
+
+
+def classify_direct_issue(issue: Issue) -> str:
+    """Pure decision for direct-lookup (--issue + --repo) mode.
+
+    Returns 'claim' when status:ready, 'resume' when status:in-progress,
+    'skip' otherwise.
+    """
+    if LABEL_READY in issue.labels:
+        return "claim"
+    if LABEL_IN_PROGRESS in issue.labels:
+        return "resume"
+    return "skip"
+
+
+def select_resume_targets(
+    repos: List[RepoConfig],
+    target_repo: Optional[str] = None,
+    target_issue: Optional[int] = None,
+    *,
+    list_in_progress_fn: Optional[Callable[[RepoConfig], List[Issue]]] = None,
+    window_exists_fn: Optional[Callable[[str], bool]] = None,
+) -> List[Issue]:
+    """In-progress issues whose deterministic PM window is missing.
+
+    Applies the same target_repo / target_issue filters as pick_issue so a
+    general run with --repo or --issue cannot resume unrelated work. Pass
+    None to leave the corresponding axis unfiltered.
+
+    Side-effects only through the injected helpers, so the planner is
+    testable without invoking tmux or gh. Late-bound defaults so that
+    monkey-patching list_in_progress_issues / window_exists at the module
+    level (as tests do) is honored.
+    """
+    if list_in_progress_fn is None:
+        list_in_progress_fn = list_in_progress_issues
+    if window_exists_fn is None:
+        window_exists_fn = window_exists
+    out: List[Issue] = []
+    for repo in repos:
+        if not repo.enabled:
+            continue
+        if target_repo and repo.full_name != target_repo and repo.short_name != target_repo:
+            continue
+        for issue in list_in_progress_fn(repo):
+            if target_issue is not None and issue.number != target_issue:
+                continue
+            if not window_exists_fn(tmux_window_name(repo, issue.number)):
+                out.append(issue)
+    return out
+
+
+def _resolve_repo(repos: List[RepoConfig], name: str) -> Optional[RepoConfig]:
+    for r in repos:
+        if r.full_name == name or r.short_name == name:
+            return r
+    return None
+
+
+def dispatch_claim(issue: Issue, args) -> int:
+    """Full claim flow with partial-claim rollback.
+
+    Order: label swap -> ensure window -> claim comment -> send prompt.
+    If anything after the swap raises, attempt to revert the label so the
+    issue re-enters the queue. The resume sweep recovers it next run if
+    the rollback itself fails.
+    """
+    repo = issue.repo
+    window = tmux_window_name(repo, issue.number)
+    window_preexisted = False
+
+    if not args.dry_run and window_exists(window):
+        window_preexisted = True
+        print(
+            f"SKIP: deterministic window {window} already exists for "
+            f"{repo.full_name}#{issue.number}; refusing to dispatch a duplicate PM.\n"
+            f"      Attach with: tmux attach -t {TMUX_SESSION}\n"
+            f"      If the existing PM is dead: tmux kill-window -t {TMUX_SESSION}:{window}",
+            file=sys.stderr,
+        )
+        return 0
+
+    print(
+        f"Claiming {repo.full_name}#{issue.number} \"{issue.title}\"",
+        file=sys.stderr,
+    )
+    try:
+        swapped = claim_issue(issue, args.dry_run)
+    except RuntimeError as e:
+        print(
+            f"ERROR: claim failed for {repo.full_name}#{issue.number}: {e}\n"
+            f"       Aborting dispatch before tmux work.",
+            file=sys.stderr,
+        )
+        return 2
+    if not swapped:
+        print(
+            f"ERROR: claim failed for {repo.full_name}#{issue.number}; "
+            f"aborting dispatch before tmux work",
+            file=sys.stderr,
+        )
+        return 2
+    try:
+        ensure_window(repo, issue, args.dry_run)
+        post_claim_comment(issue, window, args.dry_run)
+        prompt = render_pm_prompt(args.prompt_template, issue, window)
+        send_prompt(window, prompt, args.dry_run)
+    except Exception as e:
+        if swapped:
+            print(
+                f"ERROR: dispatch failed after claim "
+                f"({type(e).__name__}: {e}).\n"
+                f"       Attempting label rollback for {repo.full_name}#{issue.number}",
+                file=sys.stderr,
+            )
+            rollback_claim(issue, args.dry_run)
+            if not args.dry_run and not window_preexisted and window_exists(window):
+                print(
+                    f"       Cleaning up newly created tmux window "
+                    f"{TMUX_SESSION}:{window}",
+                    file=sys.stderr,
+                )
+                kill_window(window, args.dry_run)
+        else:
+            print(
+                f"ERROR: dispatch failed: {type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
+        raise
+    print(
+        f"OK: dispatched PM for {repo.full_name}#{issue.number} "
+        f"-> {pm_pane_target(window)}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def dispatch_resume(issue: Issue, args) -> int:
+    """Re-attach a PM window for an already-claimed (status:in-progress) issue.
+
+    No label change. No claim comment. If the deterministic window is
+    already alive, this is a no-op.
+    """
+    repo = issue.repo
+    window = tmux_window_name(repo, issue.number)
+
+    if not args.dry_run and window_exists(window):
+        print(
+            f"SKIP: PM window {window} already running for "
+            f"{repo.full_name}#{issue.number}; nothing to resume",
+            file=sys.stderr,
+        )
+        return 0
+
+    print(f"Resuming {repo.full_name}#{issue.number} -> {window}", file=sys.stderr)
+    try:
+        ensure_window(repo, issue, args.dry_run)
+        prompt = render_pm_prompt(args.prompt_template, issue, window)
+        send_prompt(window, prompt, args.dry_run)
+    except Exception as e:
+        print(
+            f"ERROR: resume failed for {repo.full_name}#{issue.number}: "
+            f"{type(e).__name__}: {e}",
+            file=sys.stderr,
+        )
+        raise
+    print(
+        f"OK: resumed PM for {repo.full_name}#{issue.number} "
+        f"-> {pm_pane_target(window)}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description="v0.1 Launcher for tmux PM agents")
+    p.add_argument("--config", type=Path, help="repositories config path (yaml or json)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="do not mutate GitHub or tmux; print intended actions")
+    p.add_argument("--repo", help="restrict to a single repo (short or full name)")
+    p.add_argument("--issue", type=int, help="restrict to a specific issue number")
+    p.add_argument("--prompt-template", type=Path, default=DEFAULT_PROMPT_TEMPLATE)
+    args = p.parse_args(argv)
+
+    config_path = find_config(args.config)
+    repos = load_config(config_path)
+
+    # Direct-lookup mode: --issue + --repo act on that exact issue regardless
+    # of queue position. Supports both fresh claim and resume of an
+    # already-claimed issue.
+    if args.issue is not None and args.repo is not None:
+        repo = _resolve_repo(repos, args.repo)
+        if repo is None:
+            print(f"ERROR: repo '{args.repo}' is not in {config_path}", file=sys.stderr)
+            return 2
+        issue = fetch_issue(repo, args.issue)
+        if issue is None:
+            return 2
+        kind = classify_direct_issue(issue)
+        if kind == "claim":
+            return dispatch_claim(issue, args)
+        if kind == "resume":
+            return dispatch_resume(issue, args)
+        print(
+            f"SKIP: {repo.full_name}#{issue.number} has neither "
+            f"'{LABEL_READY}' nor '{LABEL_IN_PROGRESS}'; refusing to dispatch",
+            file=sys.stderr,
+        )
+        return 0
+
+    # General run:
+    #   1) resume any in-progress issues whose PM window is missing
+    #   2) claim one new status:ready issue
+    # --repo / --issue restrict both phases so a filtered general run does
+    # not touch unrelated repos or issues.
+    resume_targets = select_resume_targets(
+        repos, target_repo=args.repo, target_issue=args.issue,
+    )
+    for issue in resume_targets:
+        try:
+            dispatch_resume(issue, args)
+        except Exception:
+            # already logged; keep sweeping other resume targets
+            pass
+
+    issue = pick_issue(repos, args.repo, args.issue)
+    if issue is None:
+        if not resume_targets:
+            print("No status:ready issue found.", file=sys.stderr)
+        return 0
+    return dispatch_claim(issue, args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/u_agents/launcher.py
+++ b/u_agents/launcher.py
@@ -101,7 +101,15 @@ def _list_by_label(repo: RepoConfig, label: str) -> List[Issue]:
         return []
     if not res.stdout.strip():
         return []
-    data = json.loads(res.stdout)
+    try:
+        data = json.loads(res.stdout)
+    except json.JSONDecodeError as e:
+        print(
+            f"WARN: gh issue list returned malformed JSON for "
+            f"{repo.full_name}: {e}",
+            file=sys.stderr,
+        )
+        return []
     out: List[Issue] = []
     for it in data:
         labels = [l.get("name", "") for l in it.get("labels", [])]

--- a/u_agents/prompts/pm.md
+++ b/u_agents/prompts/pm.md
@@ -1,0 +1,88 @@
+You are the PM agent for GitHub issue {repo_full}#{issue_number} ("{issue_title}").
+
+Issue URL: {issue_url}
+
+# Runtime contract
+
+- tmux session: {tmux_session}
+- tmux window:  {tmux_window}   (do NOT rename this window)
+- your pane:    {pm_pane}       (pane title: pm)
+- repo:         {repo_full}
+- main checkout:{main_checkout}
+- worktrees dir:{worktrees_root}
+- target branch:{branch}
+- target wt:    {worktree}
+
+GitHub Issues / PRs / CI are the source of truth. You own the workflow for
+this one issue. You do not own state for any other issue.
+
+# Workflow you must execute
+
+1. workspace
+   - If a git worktree already exists at {worktree}, reuse it.
+   - Else create it from {main_checkout}: `git -C {main_checkout} worktree add -b {branch} {worktree}` (fall back to checking out an existing remote branch with the same name if present).
+   - cd into {worktree} for all subsequent work.
+
+2. clarify
+   - Read the GitHub issue with `gh issue view {issue_number} --repo {repo_full}`.
+   - Extract goal, in-scope, out-of-scope, done-when, and any hard blockers.
+   - If requirements are ambiguous, comment on the issue with the specific
+     question and stop. Do not guess.
+
+3. implement (engineer pane)
+   - Split this window so an engineer pane exists alongside yours. Title it `engineer`.
+   - Send the engineer a self-contained brief that includes: repo, issue
+     number, worktree path, branch, the requirements/specs you derived,
+     and the done-when criteria.
+   - Watch the engineer pane until it reports done or blocked.
+
+4. review (reviewer pane)
+   - When implementation is done, split off a reviewer pane titled `reviewer`.
+   - Ask the reviewer to run `review-diff` (or the project's equivalent) on
+     the diff between this branch and the default branch.
+   - Collect findings. Categorize as: must-fix, optional, rejected.
+
+5. fix loop (bounded)
+   - If must-fix findings exist, send them back to the engineer pane with
+     concrete file/line references. After the engineer reports done, go back
+     to step 4.
+   - Cap the loop at 3 review rounds. After the cap, comment on the issue
+     with the remaining disagreement and stop.
+
+6. PR
+   - When review is clean, push the branch and open a review-ready PR with
+     `gh pr create --base {default_branch} --head {branch}`.
+   - PR body should reference the issue (`Closes #{issue_number}`) and
+     summarize what shipped, how it was verified, and any follow-ups.
+   - Do not force push. Do not merge.
+
+7. report
+   - Post a completion summary as a comment on the issue using this format:
+
+     PM summary:
+     - status: ready_for_review | blocked | pr_open
+     - files changed:
+     - verification:
+     - review result:
+     - next action needed:
+
+# Watchdog protocol
+
+A separate watchdog watches your pane output. If your pane is unchanged
+for several consecutive checks, it will paste:
+
+    You may be stalled. Please report current status, blocker, and next action.
+
+When you see that line, immediately print a one-line status of what you are
+waiting on (engineer pane, review pane, user input, CI, etc.) and what you
+will do next. Do not ignore the ping.
+
+# Rules
+
+- Do not rename {tmux_window} or your pane.
+- Do not touch other issues' worktrees, branches, or windows.
+- Do not push to the default branch directly.
+- Do not force push.
+- If you discover the issue is too large or fundamentally underspecified,
+  stop and comment on the issue with the specific decision needed from the
+  user.

--- a/u_agents/watchdog.py
+++ b/u_agents/watchdog.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
 
@@ -63,7 +63,34 @@ def load_state(state_file: Path) -> Dict[str, WindowState]:
             file=sys.stderr,
         )
         return {}
-    return {k: WindowState(**v) for k, v in raw.items()}
+    if not isinstance(raw, dict):
+        print(
+            f"WARN: watchdog state file {state_file} has invalid root schema; "
+            f"resetting to empty",
+            file=sys.stderr,
+        )
+        return {}
+
+    allowed_fields = {f.name for f in fields(WindowState)}
+    state: Dict[str, WindowState] = {}
+    for k, v in raw.items():
+        if not isinstance(v, dict):
+            print(
+                f"WARN: watchdog state entry {k!r} in {state_file} has invalid "
+                f"schema; skipping",
+                file=sys.stderr,
+            )
+            continue
+        filtered = {name: value for name, value in v.items() if name in allowed_fields}
+        try:
+            state[k] = WindowState(**filtered)
+        except TypeError as e:
+            print(
+                f"WARN: watchdog state entry {k!r} in {state_file} is invalid "
+                f"({e}); skipping",
+                file=sys.stderr,
+            )
+    return state
 
 
 def save_state(state_file: Path, state: Dict[str, WindowState]) -> None:

--- a/u_agents/watchdog.py
+++ b/u_agents/watchdog.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""v0.1 lightweight watchdog for tmux PM agents.
+
+Periodically captures each PM pane, compares with stored hashes, pings the
+pane if it is unchanged across several consecutive checks, and posts a
+single GitHub issue comment if it is still unchanged after the ping.
+
+The watchdog does not own workflow state. It only detects stalls.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple
+
+from u_agents.contract import (
+    RepoConfig,
+    TMUX_SESSION,
+    load_config,
+    parse_window_name,
+    pm_pane_target,
+)
+
+_XDG_STATE = Path(os.environ.get("XDG_STATE_HOME", str(Path.home() / ".local" / "state")))
+DEFAULT_STATE_DIR = _XDG_STATE / "u-agents"
+DEFAULT_STATE_FILE = "watchdog.json"
+
+PING_TEXT = (
+    "You may be stalled. Please report current status, blocker, and next action."
+)
+
+
+@dataclass
+class WindowState:
+    last_hash: str = ""
+    unchanged_checks: int = 0
+    pinged: bool = False
+    stall_comment_posted: bool = False
+    last_update: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------------------
+
+def load_state(state_file: Path) -> Dict[str, WindowState]:
+    if not state_file.exists():
+        return {}
+    try:
+        text = state_file.read_text(encoding="utf-8")
+        raw = json.loads(text) if text.strip() else {}
+    except (json.JSONDecodeError, OSError) as e:
+        print(
+            f"WARN: watchdog state file {state_file} is unreadable ({e}); resetting to empty",
+            file=sys.stderr,
+        )
+        return {}
+    return {k: WindowState(**v) for k, v in raw.items()}
+
+
+def save_state(state_file: Path, state: Dict[str, WindowState]) -> None:
+    """Atomically persist state. Crash mid-write cannot corrupt state_file."""
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(
+        {k: asdict(v) for k, v in state.items()}, indent=2, sort_keys=True,
+    )
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=state_file.name + ".",
+        suffix=".tmp",
+        dir=str(state_file.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(payload)
+        os.replace(tmp_path, state_file)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# tmux + gh side-effects (overridable for tests)
+# ---------------------------------------------------------------------------
+
+def list_managed_windows() -> List[str]:
+    res = subprocess.run(
+        ["tmux", "list-windows", "-t", TMUX_SESSION, "-F", "#{window_name}"],
+        capture_output=True, text=True,
+    )
+    if res.returncode != 0:
+        return []
+    out = []
+    for w in res.stdout.splitlines():
+        if parse_window_name(w):
+            out.append(w)
+    return out
+
+
+def capture_pane(window: str) -> str:
+    res = subprocess.run(
+        ["tmux", "capture-pane", "-p", "-t", pm_pane_target(window)],
+        capture_output=True, text=True,
+    )
+    if res.returncode != 0:
+        return ""
+    return res.stdout
+
+
+def send_ping(window: str, dry_run: bool) -> bool:
+    pane = pm_pane_target(window)
+    if dry_run:
+        print(f"DRY: ping {pane}", file=sys.stderr)
+        return True
+    # -l sends literal text without interpreting "Enter" etc.
+    text_res = subprocess.run(
+        ["tmux", "send-keys", "-t", pane, "-l", PING_TEXT],
+        capture_output=True, text=True, check=False,
+    )
+    if text_res.returncode != 0:
+        print(
+            f"WARN: watchdog ping failed for {pane}: {text_res.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return False
+    enter_res = subprocess.run(
+        ["tmux", "send-keys", "-t", pane, "Enter"],
+        capture_output=True, text=True, check=False,
+    )
+    if enter_res.returncode != 0:
+        print(
+            f"WARN: watchdog ping submit failed for {pane}: {enter_res.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def build_stall_comment_body(
+    window: str,
+    capture: str,
+    unchanged_checks: int,
+    *,
+    include_tail: bool = False,
+) -> str:
+    """Body for the GitHub stall comment.
+
+    By default the body contains only safe metadata (tmux target, unchanged
+    count, and a local inspection command). Pane content is not posted to
+    GitHub by default because a PM pane can contain file contents, command
+    output, API responses, local paths, or secrets that scrolled past the
+    terminal during normal operation.
+
+    Set include_tail=True to opt into posting the last 30 lines of the pane.
+    When opted in, the tail is HTML-escaped inside a <pre> block to neutralize
+    Markdown fence-injection from the captured content.
+    """
+    pane = pm_pane_target(window)
+    lines = [
+        f"PM watchdog: pane `{pane}` is unchanged after a ping. "
+        f"Please check the agent.",
+        "",
+        f"unchanged-check count: {unchanged_checks}",
+        "",
+        "Inspect locally (pane content is intentionally not posted here):",
+        "```sh",
+        f"tmux attach -t {TMUX_SESSION} \\; select-window -t '{TMUX_SESSION}:{window}'",
+        "```",
+    ]
+    if include_tail:
+        tail = "\n".join(capture.splitlines()[-30:])
+        # HTML-escape <, >, & so a captured Markdown code fence cannot break
+        # out of the <pre> block.
+        safe = (
+            tail.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+        )
+        lines += [
+            "",
+            "<details><summary>last pane tail (sensitive: may contain secrets, "
+            "paths, or file contents from the PM pane)</summary>",
+            "",
+            "<pre>",
+            safe,
+            "</pre>",
+            "</details>",
+        ]
+    return "\n".join(lines)
+
+
+def post_stall_comment(
+    repo_full: str,
+    issue_number: int,
+    window: str,
+    capture: str,
+    unchanged_checks: int,
+    dry_run: bool,
+    *,
+    include_tail: bool = False,
+) -> None:
+    body = build_stall_comment_body(
+        window, capture, unchanged_checks, include_tail=include_tail,
+    )
+    if dry_run:
+        print(
+            f"DRY: would comment stall on {repo_full}#{issue_number} "
+            f"(include_tail={include_tail})",
+            file=sys.stderr,
+        )
+        return
+    res = subprocess.run(
+        [
+            "gh", "issue", "comment", str(issue_number),
+            "--repo", repo_full, "--body", body,
+        ],
+        capture_output=True, text=True,
+    )
+    if res.returncode != 0:
+        print(
+            f"WARN: stall comment failed for {repo_full}#{issue_number}: "
+            f"{res.stderr.strip()}",
+            file=sys.stderr,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Core check
+# ---------------------------------------------------------------------------
+
+def _hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()
+
+
+def resolve_repo(window: str, repos: List[RepoConfig]) -> Optional[Tuple[RepoConfig, int]]:
+    parsed = parse_window_name(window)
+    if not parsed:
+        return None
+    short, num = parsed
+    for r in repos:
+        if r.short_name == short:
+            return r, num
+    return None
+
+
+def check_once(
+    repos: List[RepoConfig],
+    state_file: Path,
+    stall_checks: int,
+    dry_run: bool,
+    *,
+    list_windows: Callable[[], List[str]] = list_managed_windows,
+    capture: Callable[[str], str] = capture_pane,
+    ping: Callable[[str, bool], bool] = send_ping,
+    comment: Callable[[str, int, str, str, int, bool], None] = post_stall_comment,
+    now: Callable[[], float] = time.time,
+) -> Dict[str, WindowState]:
+    """Single check pass. Returns the updated in-memory state."""
+    state = load_state(state_file)
+    windows = list_windows()
+    seen: set[str] = set()
+
+    for w in windows:
+        seen.add(w)
+        text = capture(w)
+        h = _hash(text)
+        st = state.get(w, WindowState())
+
+        if h != st.last_hash:
+            st = WindowState(last_hash=h, unchanged_checks=0, pinged=False,
+                             stall_comment_posted=False, last_update=now())
+        else:
+            st.unchanged_checks += 1
+            st.last_update = now()
+            if st.unchanged_checks >= stall_checks and not st.pinged:
+                try:
+                    ping(w, dry_run)
+                except Exception as e:
+                    print(
+                        f"WARN: watchdog ping raised for {pm_pane_target(w)}: "
+                        f"{type(e).__name__}: {e}",
+                        file=sys.stderr,
+                    )
+                st.pinged = True
+            elif (
+                st.pinged
+                and st.unchanged_checks >= stall_checks * 2
+                and not st.stall_comment_posted
+            ):
+                resolved = resolve_repo(w, repos)
+                if resolved is None:
+                    print(
+                        f"WARN: cannot resolve repo for window {w}; skipping stall comment",
+                        file=sys.stderr,
+                    )
+                else:
+                    repo, num = resolved
+                    comment(repo.full_name, num, w, text, st.unchanged_checks, dry_run)
+                    st.stall_comment_posted = True
+        state[w] = st
+
+    for w in list(state.keys()):
+        if w not in seen:
+            del state[w]
+
+    save_state(state_file, state)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _resolve_config(explicit: Optional[Path]) -> Path:
+    # Delegate to launcher's resolution to keep config discovery in one place.
+    from u_agents.launcher import find_config
+    return find_config(explicit)
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description="v0.1 PM pane watchdog")
+    p.add_argument("--config", type=Path)
+    p.add_argument("--state-dir", type=Path, default=DEFAULT_STATE_DIR)
+    p.add_argument("--interval", type=int, default=60,
+                   help="seconds between checks (loop mode)")
+    p.add_argument("--stall-checks", type=int, default=3,
+                   help="consecutive unchanged checks before pinging")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--once", action="store_true",
+                   help="run a single check pass and exit")
+    p.add_argument(
+        "--include-pane-tail",
+        action="store_true",
+        help=("opt in to embedding the last 30 lines of the PM pane in stall "
+              "GitHub comments. SENSITIVE: pane output may contain secrets, "
+              "file contents, paths, or API responses. Off by default."),
+    )
+    args = p.parse_args(argv)
+
+    config_path = _resolve_config(args.config)
+    repos = load_config(config_path)
+    state_file = args.state_dir / DEFAULT_STATE_FILE
+
+    def comment_with_flag(repo_full, num, w, text, unchanged, dry):
+        post_stall_comment(
+            repo_full, num, w, text, unchanged, dry,
+            include_tail=args.include_pane_tail,
+        )
+
+    def run_once():
+        check_once(
+            repos, state_file, args.stall_checks, args.dry_run,
+            comment=comment_with_flag,
+        )
+
+    if args.once:
+        run_once()
+        return 0
+
+    try:
+        while True:
+            try:
+                run_once()
+            except Exception as e:  # don't let one bad check kill the loop
+                print(f"watchdog: {type(e).__name__}: {e}", file=sys.stderr)
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add the local u-agents runner package for tmux/GitHub issue orchestration
- add repository config examples and launchd job examples
- document setup, scheduling, watchdog behavior, and verification
- add unit tests for contract, launcher, watchdog, and launchd examples

## Validation
- python3 -m unittest discover tests
- python3 -m u_agents.launcher --help
- python3 -m u_agents.watchdog --help

Related: uuta/u#5