### PR TITLE
Wire u_agents agent_runs DB into runtime workflow

### DIFF
--- a/docs/u-agents.md
+++ b/docs/u-agents.md
@@ -1,8 +1,9 @@
-# v0.1 local agent runner
+# v0.2 DB-backed local agent runner
 
 Small local runner around tmux + git + `gh` for the workflow described in
-[#5](https://github.com/uuta/u/issues/5). GitHub Issues / PRs / CI are the
-source of truth. There is no ops DB, no daemon, no vector store.
+[#5](https://github.com/uuta/u/issues/5). GitHub Issues / PRs / CI, tmux,
+git worktrees, and `tmp/review-result.json` remain the external realities.
+PostgreSQL `agent_runs` coordinates claimed work across runner processes.
 
 ## Components
 
@@ -13,6 +14,7 @@ source of truth. There is no ops DB, no daemon, no vector store.
 | Launcher   | `u_agents/launcher.py`          | Short-lived starter/resumer. Picks one ready issue and hands off PM. |
 | PM prompt  | `u_agents/prompts/pm.md`        | The contract sent into the PM pane. PM owns the per-issue workflow.  |
 | Watchdog   | `u_agents/watchdog.py`          | Detects stalled PM panes. Pings, then comments once if still stuck.  |
+| PR Watcher | `u_agents/pr_watcher.py`        | Watches verified PR state and updates PR phases in `agent_runs`.     |
 | DB schema   | `u_agents/db/001_agent_runs.sql` | v0.2 PostgreSQL schema for claimed runs.                         |
 | DB docs     | `u_agents/db/README.md`         | Column ownership, phase contract, and PR watcher rules.             |
 | Config     | `u_agents/config/repositories.yml` | Local allowlist of repositories the Launcher may operate on.     |
@@ -28,8 +30,13 @@ source of truth. There is no ops DB, no daemon, no vector store.
   `U_AGENTS_CLAUDE_COMMAND` if needed.)
 - `git`
 - `yq` (MikeFarah; only needed for YAML configs — `.json` configs do not require it)
-- Docker, only for the v0.2 PostgreSQL control plane. It is not required for
-  the current launcher/watchdog runtime.
+- Docker, for the local PostgreSQL control plane.
+- `psycopg` for live DB runtime connections. The import is lazy, so unit tests
+  and `--help` paths still work without it:
+
+  ```sh
+  python3 -m pip install 'psycopg[binary]'
+  ```
 
 ## Configuration
 
@@ -137,7 +144,7 @@ The v0.2 database contract is defined in `u_agents/db/README.md` and
 claimed work only. GitHub Issues with `status:ready` remain the queue source
 of truth; DB rows are created only after the Launcher claims or leases work.
 
-Claim order for the future DB-backed Launcher is:
+Launcher claim order is:
 
 1. Observe a `status:ready` GitHub issue.
 2. Acquire/upsert the DB claim and lease in `agent_runs`.
@@ -158,6 +165,10 @@ Required runner environment for DB-backed operation:
 | `U_AGENTS_MACHINE_ID` | Stable machine identity from config/env. |
 
 Agents must not invent `U_AGENTS_RUNNER_ID` or `U_AGENTS_MACHINE_ID`.
+Blank values and placeholders such as `runner`, `machine`, `placeholder`,
+`changeme`, `todo`, or `example` are rejected. Launcher dry-runs require the
+runner and machine identity because the dry-run output includes the DB claim
+lease owner; live DB paths also require `U_AGENTS_DATABASE_URL` and `psycopg`.
 
 ## Commands
 
@@ -172,6 +183,7 @@ mise run launcher-dry-run   # python3 -m u_agents.launcher --dry-run
 mise run launcher           # python3 -m u_agents.launcher
 mise run watchdog-dry-run   # python3 -m u_agents.watchdog --once --dry-run
 mise run watchdog           # python3 -m u_agents.watchdog --once
+mise run pr-watcher         # python3 -m u_agents.pr_watcher --once
 mise run test               # python3 -m unittest discover tests
 mise run db-up              # docker compose -f compose.yml up -d --wait postgres
 mise run db-psql            # psql into local Postgres
@@ -203,7 +215,8 @@ python3 -m u_agents.launcher --config ~/my-repos.yml
 ```
 
 `--dry-run` suppresses all writes (label swap, claim comment, tmux window
-creation, prompt send) but still reads issue state from GitHub.
+creation, prompt send, DB write) but still reads issue state from GitHub and
+prints the `agent_runs` claim/lease and `pm_started` update it would perform.
 
 #### Resume and partial-claim recovery
 
@@ -224,6 +237,11 @@ Direct-lookup mode (`--issue N --repo R`) bypasses the queue and supports
 both fresh claim and resume of an already-claimed issue.
 
 ### Watchdog
+
+The watchdog discovers active and stale work from `agent_runs`, then verifies
+GitHub issue state and live tmux windows before pinging or commenting. If a DB
+row points at a missing tmux window/pane, the watchdog records an observation
+in `agent_runs` and skips pane action rather than trusting the row blindly.
 
 ```sh
 # single check pass and exit (useful from cron)
@@ -251,17 +269,44 @@ Pane content is never posted unless `--include-pane-tail` is set; when set,
 the tail is HTML-escaped inside a `<pre>` block to neutralize Markdown
 fence-injection from captured output.
 
-State is persisted to `<dotfiles checkout>/u_agents/state/watchdog.json` by
-default, anchored to the installed `u_agents` package directory rather than
-the process current working directory. Override with `--state-dir` when you
-want a different runtime location. The state write uses atomic
-`tempfile + os.replace`, so a crash mid-write cannot corrupt the file.
-`u_agents/state/` is local runtime data and ignored by git. If the state
-file does become unreadable (manual edit, disk truncation), `load_state`
-warns and resets to empty instead of deadlocking the watchdog loop.
+`agent_runs` is the shared task/phase source. The local
+`<dotfiles checkout>/u_agents/state/watchdog.json` file stores only pane-stall
+details: last pane hash, unchanged-check count, pinged flag, and whether a
+stall comment was already posted. It is anchored to the installed `u_agents`
+package directory rather than the process current working directory. Override
+with `--state-dir` when you want a different runtime location. The state write
+uses atomic `tempfile + os.replace`, so a crash mid-write cannot corrupt the
+file. `u_agents/state/` is local runtime data and ignored by git. If the state
+file does become unreadable (manual edit, disk truncation), `load_state` warns
+and resets to empty instead of deadlocking the watchdog loop.
 
 Stalled-once-and-commented windows do not get re-commented until their pane
 output changes.
+
+### PR Watcher
+
+The PR watcher reads `agent_runs` rows in `pr_open`, `pr_watching`, and
+`ready_to_merge`, then verifies GitHub PR reality before any transition:
+the PR must exist, its head branch must match `branch_name`, and merged/closed,
+CI, and review-comment state are re-read from GitHub.
+
+```sh
+python3 -m u_agents.pr_watcher --once
+mise run pr-watcher
+```
+
+Transition rules:
+
+1. Merged PR -> `done`.
+2. Must-fix PR comments with `pr_review_fix_rounds = 0` -> `fixing`, increment
+   `pr_review_fix_rounds`, and assign one automated fix loop.
+3. Must-fix PR comments with `pr_review_fix_rounds >= 1` -> `blocked`.
+4. Green CI and no must-fix comments -> `ready_to_merge`.
+5. Otherwise -> `pr_watching`.
+
+The watcher records `pr_number`, `pr_review_fix_rounds`, `block_reason`, and
+small observations in `metadata`. It never auto-merges; `ready_to_merge` means
+the user/operator can merge after their own final check.
 
 Suggested cron entry (single check per minute):
 
@@ -361,10 +406,13 @@ GitHub issue with status:ready
         ▼
    Launcher picks one
         │
+        ├─ acquires/upserts agent_runs claim + lease
+        ├─ re-verifies issue open + status:ready
         ├─ swaps status:ready -> status:in-progress
         ├─ posts claim comment with tmux/worktree/branch coords
         ├─ ensures `agents:<window>` exists
-        └─ sends PM prompt into the window
+        ├─ sends PM prompt into the window
+        └─ writes phase=pm_started with tmux coords
                 │
                 ▼
         PM (tmux pane)
@@ -376,20 +424,30 @@ GitHub issue with status:ready
                 ├─ fix loop bounded to 3 rounds
                 └─ opens review-ready PR with `Closes #N`
 
+        PR Watcher
+                │
+                ├─ verifies PR exists and head branch matches
+                ├─ watches CI + review comments
+                ├─ assigns at most one automated PR review fix loop
+                └─ sets ready_to_merge / done / blocked
+
         Watchdog (separate loop)
                 │
+                ├─ reads active/stale agent_runs rows
+                ├─ verifies GitHub issue + tmux reality
                 ├─ capture-pane → hash → compare
                 ├─ N unchanged checks → tmux send-keys ping
                 └─ 2N unchanged after ping → one issue comment, then quiet
 ```
 
-## What this v0.1 deliberately does not do
+## Boundaries
 
-- No Postgres / Redis / Temporal / message queues.
 - No long-running daemon.
 - No semantic memory / vector DB.
-- No multi-machine locking. Single-Launcher single-machine assumption.
-- No PR / CI / merged status labels — those are reconstructed from GitHub.
+- No queued/discovered ready issues in the DB before launcher claim.
+- No PM/engineer/reviewer creation of the initial `agent_runs` row.
+- No absolute worktree paths in `agent_runs`; store `worktree_basename` only.
+- No automatic PR merge.
 - No automatic worktree cleanup. Cleanup happens manually after PR merge.
 
 ## Verification
@@ -398,8 +456,10 @@ GitHub issue with status:ready
 python3 -m unittest discover tests
 python3 -m u_agents.launcher --help
 python3 -m u_agents.watchdog --help
-python3 -m u_agents.watchdog --once --dry-run   # works without any active tmux windows
+python3 -m u_agents.pr_watcher --help
 ```
 
-A live Launcher dry-run requires `gh auth login` against the configured
-repositories.
+Live `launcher`, `watchdog`, and `pr_watcher` runs require `gh auth login`, DB
+environment variables, `psycopg`, and reachable local Postgres. A launcher
+dry-run also requires `U_AGENTS_RUNNER_ID` and `U_AGENTS_MACHINE_ID` so it can
+show the DB claim owner it would use.

--- a/tests/test_agent_runs.py
+++ b/tests/test_agent_runs.py
@@ -1,0 +1,246 @@
+import json
+import unittest
+from datetime import datetime, timezone
+
+from u_agents.agent_runs import (
+    AgentRunsClient,
+    ClaimPayload,
+    build_claim_payload,
+)
+from u_agents.contract import REVIEW_RESULT_RELATIVE_PATH, RepoConfig
+from u_agents.control_plane import RunnerIdentity
+
+
+def _row(**overrides):
+    base = {
+        "repository_full_name": "o/r",
+        "github_issue_number": 12,
+        "parent_branch": "main",
+        "branch_name": "feat/12",
+        "phase": "claimed",
+        "runner_id": "runner-1",
+        "machine_id": "machine-1",
+        "locked_by": "runner-1@machine-1",
+        "lease_until": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "worktree_basename": "12",
+        "tmux_window": "r-12",
+        "pm_pane": None,
+        "pr_number": None,
+        "pr_review_fix_rounds": 0,
+        "block_reason": None,
+        "metadata": {},
+    }
+    base.update(overrides)
+    return base
+
+
+class FakeCursor:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+    def execute(self, sql, params):
+        self.conn.calls.append((sql, params))
+
+    def fetchone(self):
+        if not self.conn.rows:
+            return None
+        return self.conn.rows.pop(0)
+
+    def fetchall(self):
+        rows = self.conn.rows
+        self.conn.rows = []
+        return rows
+
+
+class FakeConn:
+    def __init__(self, rows):
+        self.rows = list(rows)
+        self.calls = []
+        self.commits = 0
+
+    def cursor(self):
+        return FakeCursor(self)
+
+    def commit(self):
+        self.commits += 1
+
+
+class TestClaimPayload(unittest.TestCase):
+    def test_build_claim_payload_uses_portable_worktree_basename(self):
+        repo = RepoConfig("o/r", "/workspace/r", "main")
+        identity = RunnerIdentity("runner-1", "machine-1")
+        payload = build_claim_payload(
+            repo,
+            12,
+            "feat/12",
+            identity,
+            now=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(payload.repository_full_name, "o/r")
+        self.assertEqual(payload.github_issue_number, 12)
+        self.assertEqual(payload.parent_branch, "main")
+        self.assertEqual(payload.branch_name, "feat/12")
+        self.assertEqual(payload.worktree_basename, "12")
+        self.assertNotIn("/workspace", payload.worktree_basename)
+        self.assertEqual(
+            payload.review_result_relative_path,
+            REVIEW_RESULT_RELATIVE_PATH,
+        )
+
+    def test_rejects_invalid_claim_payload_before_db_write(self):
+        conn = FakeConn([_row()])
+        client = AgentRunsClient(conn, RunnerIdentity("runner-1", "machine-1"))
+        payload = ClaimPayload(
+            repository_full_name="not-a-full-name",
+            github_issue_number=0,
+            parent_branch="main branch",
+            branch_name="feat/12",
+            runner_id="runner",
+            machine_id="machine-1",
+            locked_by="runner@machine-1",
+            lease_until=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            worktree_basename="../12",
+            tmux_window="r-12",
+            review_result_relative_path="tmp/wrong.json",
+        )
+
+        with self.assertRaises(Exception):
+            client.acquire_claim(payload)
+        self.assertEqual(conn.calls, [])
+
+    def test_rejects_non_contract_review_result_path_before_db_write(self):
+        conn = FakeConn([_row()])
+        client = AgentRunsClient(conn, RunnerIdentity("runner-1", "machine-1"))
+        payload = ClaimPayload(
+            repository_full_name="o/r",
+            github_issue_number=12,
+            parent_branch="main",
+            branch_name="feat/12",
+            runner_id="runner-1",
+            machine_id="machine-1",
+            locked_by="runner-1@machine-1",
+            lease_until=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            worktree_basename="12",
+            tmux_window="r-12",
+            review_result_relative_path="tmp/other.json",
+        )
+
+        with self.assertRaisesRegex(ValueError, "tmp/review-result.json"):
+            client.acquire_claim(payload)
+        self.assertEqual(conn.calls, [])
+
+
+class TestAgentRunsClientWrites(unittest.TestCase):
+    def setUp(self):
+        self.identity = RunnerIdentity("runner-1", "machine-1")
+
+    def test_acquire_claim_generates_expected_upsert_payload(self):
+        conn = FakeConn([_row()])
+        client = AgentRunsClient(conn, self.identity)
+        repo = RepoConfig("o/r", "/workspace/r", "main")
+        payload = build_claim_payload(
+            repo,
+            12,
+            "feat/12",
+            self.identity,
+            now=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+
+        run = client.acquire_claim(payload)
+
+        self.assertEqual(run.repository_full_name, "o/r")
+        self.assertEqual(run.github_issue_number, 12)
+        self.assertEqual(conn.commits, 1)
+        sql, params = conn.calls[0]
+        self.assertIn("INSERT INTO agent_runs", sql)
+        self.assertIn("ON CONFLICT (repository_full_name, github_issue_number)", sql)
+        self.assertIn("review_result_relative_path", sql)
+        self.assertEqual(params["repository_full_name"], "o/r")
+        self.assertEqual(params["github_issue_number"], 12)
+        self.assertEqual(params["worktree_basename"], "12")
+        self.assertEqual(
+            params["review_result_relative_path"],
+            REVIEW_RESULT_RELATIVE_PATH,
+        )
+
+    def test_update_phase_generates_expected_update_payload(self):
+        conn = FakeConn([_row(phase="engineering", metadata={"stage": "pm"})])
+        client = AgentRunsClient(conn, self.identity)
+
+        run = client.update_phase(
+            "o/r",
+            12,
+            "engineering",
+            metadata={"stage": "pm"},
+        )
+
+        self.assertEqual(run.phase, "engineering")
+        sql, params = conn.calls[0]
+        self.assertIn("UPDATE agent_runs", sql)
+        self.assertIn("SET phase = %(phase)s", sql)
+        self.assertEqual(params["phase"], "engineering")
+        self.assertEqual(json.loads(params["metadata"]), {"stage": "pm"})
+        self.assertFalse(params["clear_lease"])
+
+    def test_update_tmux_coordinates_writes_pm_started_payload(self):
+        conn = FakeConn([_row(phase="pm_started", pm_pane="agents:r-12.0")])
+        client = AgentRunsClient(conn, self.identity)
+
+        run = client.update_tmux_coordinates(
+            "o/r",
+            12,
+            tmux_window="r-12",
+            pm_pane="agents:r-12.0",
+        )
+
+        self.assertEqual(run.phase, "pm_started")
+        self.assertEqual(run.pm_pane, "agents:r-12.0")
+        _sql, params = conn.calls[0]
+        self.assertEqual(params["phase"], "pm_started")
+        self.assertEqual(params["tmux_window"], "r-12")
+        self.assertEqual(params["pm_pane"], "agents:r-12.0")
+
+    def test_update_pr_fields_can_increment_once(self):
+        conn = FakeConn([_row(phase="fixing", pr_number=45, pr_review_fix_rounds=1)])
+        client = AgentRunsClient(conn, self.identity)
+
+        run = client.update_pr_fields(
+            "o/r",
+            12,
+            pr_number=45,
+            phase="fixing",
+            increment_fix_rounds=True,
+            metadata={"pr_watcher": {"verified": True}},
+        )
+
+        self.assertEqual(run.phase, "fixing")
+        self.assertEqual(run.pr_review_fix_rounds, 1)
+        _sql, params = conn.calls[0]
+        self.assertEqual(params["pr_number"], 45)
+        self.assertEqual(params["phase"], "fixing")
+        self.assertTrue(params["increment_fix_rounds"])
+
+    def test_list_active_and_stale_runs_use_domain_phases(self):
+        active_conn = FakeConn([_row(phase="pm_started")])
+        active_client = AgentRunsClient(active_conn, self.identity)
+        self.assertEqual(active_client.list_active_runs()[0].phase, "pm_started")
+        active_sql, active_params = active_conn.calls[0]
+        self.assertIn("phase = ANY(%(phases)s)", active_sql)
+        self.assertIn("pm_started", active_params["phases"])
+
+        stale_conn = FakeConn([_row(phase="engineering")])
+        stale_client = AgentRunsClient(stale_conn, self.identity)
+        self.assertEqual(stale_client.list_stale_runs()[0].phase, "engineering")
+        stale_sql, _stale_params = stale_conn.calls[0]
+        self.assertIn("lease_until < now()", stale_sql)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agent_runs.py
+++ b/tests/test_agent_runs.py
@@ -241,6 +241,15 @@ class TestAgentRunsClientWrites(unittest.TestCase):
         stale_sql, _stale_params = stale_conn.calls[0]
         self.assertIn("lease_until < now()", stale_sql)
 
+    def test_list_methods_commit_after_select(self):
+        # Comment 4: a bare SELECT opens a transaction in PostgreSQL; the list
+        # (_fetch_all) methods must commit so the connection is left clean.
+        for method in ("list_active_runs", "list_stale_runs", "list_pr_watch_runs"):
+            conn = FakeConn([_row(phase="pr_watching", pr_number=45)])
+            client = AgentRunsClient(conn, self.identity)
+            getattr(client, method)()
+            self.assertEqual(conn.commits, 1, f"{method} should commit once")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -57,6 +57,26 @@ class TestRunnerEnvironment(unittest.TestCase):
         with self.assertRaisesRegex(ConfigError, "U_AGENTS_MACHINE_ID"):
             load_runner_identity({"U_AGENTS_RUNNER_ID": "runner-1", "U_AGENTS_MACHINE_ID": " "})
 
+    def test_runner_identity_rejects_placeholders(self):
+        placeholders = ("runner", "runner-id", "placeholder", "changeme", "todo")
+        for value in placeholders:
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ConfigError, "placeholder identity"):
+                    load_runner_identity({
+                        "U_AGENTS_RUNNER_ID": value,
+                        "U_AGENTS_MACHINE_ID": "machine-1",
+                    })
+
+    def test_machine_identity_rejects_placeholders(self):
+        placeholders = ("machine", "machine-id", "example")
+        for value in placeholders:
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ConfigError, "placeholder identity"):
+                    load_runner_identity({
+                        "U_AGENTS_RUNNER_ID": "runner-1",
+                        "U_AGENTS_MACHINE_ID": value,
+                    })
+
     def test_database_url_is_required(self):
         with self.assertRaisesRegex(ConfigError, "U_AGENTS_DATABASE_URL"):
             database_url_from_env({"U_AGENTS_DATABASE_URL": ""})

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -10,6 +10,8 @@ from u_agents.contract import (
     REVIEW_RESULT_STATUSES,
     RepoConfig,
 )
+from u_agents.agent_runs import AgentRun
+from u_agents.control_plane import RunnerIdentity
 from u_agents import launcher
 from u_agents.launcher import (
     DEFAULT_CONFIG_PATHS,
@@ -32,6 +34,50 @@ def _mk_issue(repo: RepoConfig, n: int, title: str = "x",
                  labels=list(labels))
 
 
+class FakeAgentRunsClient:
+    def __init__(self, events=None):
+        self.identity = RunnerIdentity("runner-1", "machine-1")
+        self.events = [] if events is None else events
+        self.cancelled = []
+
+    def acquire_claim(self, payload):
+        self.events.append("db_claim")
+        return AgentRun(
+            repository_full_name=payload.repository_full_name,
+            github_issue_number=payload.github_issue_number,
+            parent_branch=payload.parent_branch,
+            branch_name=payload.branch_name,
+            phase=payload.phase,
+            runner_id=payload.runner_id,
+            machine_id=payload.machine_id,
+            locked_by=payload.locked_by,
+            lease_until=payload.lease_until,
+            worktree_basename=payload.worktree_basename,
+            tmux_window=payload.tmux_window,
+        )
+
+    def mark_pm_started(self, run):
+        self.events.append("pm_started")
+        return AgentRun(
+            repository_full_name=run.repository_full_name,
+            github_issue_number=run.github_issue_number,
+            parent_branch=run.parent_branch,
+            branch_name=run.branch_name,
+            phase="pm_started",
+            runner_id=run.runner_id,
+            machine_id=run.machine_id,
+            locked_by=run.locked_by,
+            lease_until=run.lease_until,
+            worktree_basename=run.worktree_basename,
+            tmux_window=run.tmux_window,
+            pm_pane=f"agents:{run.tmux_window}.0",
+        )
+
+    def cancel_run(self, repo_full, issue_number, *, metadata=None):
+        self.events.append("cancel")
+        self.cancelled.append((repo_full, issue_number, metadata or {}))
+
+
 def _args(**overrides):
     """Build a minimal argparse.Namespace matching launcher main() args."""
     defaults = dict(
@@ -40,6 +86,7 @@ def _args(**overrides):
         repo=None,
         issue=None,
         prompt_template=DEFAULT_PROMPT_TEMPLATE,
+        agent_runs_client=FakeAgentRunsClient(),
     )
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -538,6 +585,75 @@ class TestMainGeneralRunHonorsFilters(unittest.TestCase):
         self.assertEqual(claimed, [("o/a", 5)])
 
 
+class TestDbBackedClaimFlow(unittest.TestCase):
+    def setUp(self):
+        self.repo = RepoConfig("o/r", "/w/r", "main")
+        self.issue = _mk_issue(self.repo, 5, labels=[LABEL_READY])
+
+    def test_db_claim_happens_before_label_swap(self):
+        events = []
+        db = FakeAgentRunsClient(events)
+
+        def claim(_issue, _dry):
+            events.append("label_swap")
+            return True
+
+        with mock.patch("u_agents.launcher.reverify_issue_ready",
+                        return_value=self.issue), \
+             mock.patch("u_agents.launcher.window_exists", return_value=False), \
+             mock.patch("u_agents.launcher.claim_issue", side_effect=claim), \
+             mock.patch("u_agents.launcher.ensure_window",
+                        side_effect=lambda *_args: events.append("tmux") or "r-5"), \
+             mock.patch("u_agents.launcher.post_claim_comment"), \
+             mock.patch("u_agents.launcher.send_prompt",
+                        side_effect=lambda *_args: events.append("prompt")):
+            rc = dispatch_claim(self.issue, _args(agent_runs_client=db))
+
+        self.assertEqual(rc, 0)
+        self.assertLess(events.index("db_claim"), events.index("label_swap"))
+        self.assertLess(events.index("label_swap"), events.index("tmux"))
+
+    def test_no_tmux_if_post_claim_github_reverification_fails(self):
+        db = FakeAgentRunsClient()
+
+        with mock.patch("u_agents.launcher.reverify_issue_ready",
+                        return_value=None), \
+             mock.patch("u_agents.launcher.claim_issue") as m_claim, \
+             mock.patch("u_agents.launcher.ensure_window") as m_window, \
+             mock.patch("u_agents.launcher.send_prompt") as m_prompt:
+            rc = dispatch_claim(self.issue, _args(agent_runs_client=db))
+
+        self.assertEqual(rc, 0)
+        m_claim.assert_not_called()
+        m_window.assert_not_called()
+        m_prompt.assert_not_called()
+        self.assertEqual(db.cancelled[0][2]["cancel_reason"],
+                         "github_reverification_failed")
+
+    def test_pm_started_is_written_after_prompt_send(self):
+        events = []
+        db = FakeAgentRunsClient(events)
+
+        def claim(_issue, _dry):
+            events.append("label_swap")
+            return True
+
+        def send(_window, _prompt, _dry):
+            events.append("prompt_sent")
+
+        with mock.patch("u_agents.launcher.reverify_issue_ready",
+                        return_value=self.issue), \
+             mock.patch("u_agents.launcher.window_exists", return_value=False), \
+             mock.patch("u_agents.launcher.claim_issue", side_effect=claim), \
+             mock.patch("u_agents.launcher.ensure_window", return_value="r-5"), \
+             mock.patch("u_agents.launcher.post_claim_comment"), \
+             mock.patch("u_agents.launcher.send_prompt", side_effect=send):
+            rc = dispatch_claim(self.issue, _args(agent_runs_client=db))
+
+        self.assertEqual(rc, 0)
+        self.assertLess(events.index("prompt_sent"), events.index("pm_started"))
+
+
 class TestDispatchClaimRollback(unittest.TestCase):
     """Fix #3: rollback labels when dispatch fails after successful claim."""
 
@@ -546,7 +662,9 @@ class TestDispatchClaimRollback(unittest.TestCase):
         self.issue = _mk_issue(self.repo, 5, labels=[LABEL_READY])
 
     def test_rollback_called_when_send_prompt_fails_after_claim(self):
-        with mock.patch("u_agents.launcher.window_exists", return_value=False), \
+        with mock.patch("u_agents.launcher.reverify_issue_ready",
+                        return_value=self.issue), \
+             mock.patch("u_agents.launcher.window_exists", return_value=False), \
              mock.patch("u_agents.launcher.claim_issue", return_value=True) as m_claim, \
              mock.patch("u_agents.launcher.ensure_window", return_value="r-5"), \
              mock.patch("u_agents.launcher.post_claim_comment"), \
@@ -559,7 +677,9 @@ class TestDispatchClaimRollback(unittest.TestCase):
             m_rollback.assert_called_once_with(self.issue, False)
 
     def test_cleans_new_window_when_send_prompt_fails_after_claim(self):
-        with mock.patch("u_agents.launcher.window_exists",
+        with mock.patch("u_agents.launcher.reverify_issue_ready",
+                        return_value=self.issue), \
+             mock.patch("u_agents.launcher.window_exists",
                         side_effect=[False, True]) as m_exists, \
              mock.patch("u_agents.launcher.claim_issue", return_value=True), \
              mock.patch("u_agents.launcher.ensure_window", return_value="r-5"), \
@@ -574,7 +694,9 @@ class TestDispatchClaimRollback(unittest.TestCase):
             m_kill.assert_called_once_with("r-5", False)
 
     def test_does_not_cleanup_when_no_window_was_created(self):
-        with mock.patch("u_agents.launcher.window_exists",
+        with mock.patch("u_agents.launcher.reverify_issue_ready",
+                        return_value=self.issue), \
+             mock.patch("u_agents.launcher.window_exists",
                         side_effect=[False, False]), \
              mock.patch("u_agents.launcher.claim_issue", return_value=True), \
              mock.patch("u_agents.launcher.ensure_window",
@@ -587,7 +709,9 @@ class TestDispatchClaimRollback(unittest.TestCase):
 
     def test_aborts_before_tmux_when_claim_swap_failed(self):
         # If labels never swapped (claim returned False), don't dispatch.
-        with mock.patch("u_agents.launcher.window_exists", return_value=False), \
+        with mock.patch("u_agents.launcher.reverify_issue_ready",
+                        return_value=self.issue), \
+             mock.patch("u_agents.launcher.window_exists", return_value=False), \
              mock.patch("u_agents.launcher.claim_issue", return_value=False), \
              mock.patch("u_agents.launcher.ensure_window") as m_window, \
              mock.patch("u_agents.launcher.rollback_claim") as m_rollback:
@@ -597,7 +721,9 @@ class TestDispatchClaimRollback(unittest.TestCase):
             m_rollback.assert_not_called()
 
     def test_claim_exception_aborts_before_tmux(self):
-        with mock.patch("u_agents.launcher.window_exists", return_value=False), \
+        with mock.patch("u_agents.launcher.reverify_issue_ready",
+                        return_value=self.issue), \
+             mock.patch("u_agents.launcher.window_exists", return_value=False), \
              mock.patch("u_agents.launcher.claim_issue",
                         side_effect=RuntimeError("claim failed")), \
              mock.patch("u_agents.launcher.ensure_window") as m_window:
@@ -606,7 +732,9 @@ class TestDispatchClaimRollback(unittest.TestCase):
             m_window.assert_not_called()
 
     def test_no_rollback_on_clean_success(self):
-        with mock.patch("u_agents.launcher.window_exists", return_value=False), \
+        with mock.patch("u_agents.launcher.reverify_issue_ready",
+                        return_value=self.issue), \
+             mock.patch("u_agents.launcher.window_exists", return_value=False), \
              mock.patch("u_agents.launcher.claim_issue", return_value=True), \
              mock.patch("u_agents.launcher.ensure_window", return_value="r-5"), \
              mock.patch("u_agents.launcher.post_claim_comment"), \
@@ -619,7 +747,9 @@ class TestDispatchClaimRollback(unittest.TestCase):
     def test_existing_window_skips_dispatch_and_does_not_claim(self):
         # If a deterministic window already exists, refuse duplicate dispatch
         # and DO NOT swap labels.
-        with mock.patch("u_agents.launcher.window_exists", return_value=True), \
+        with mock.patch("u_agents.launcher.reverify_issue_ready",
+                        return_value=self.issue), \
+             mock.patch("u_agents.launcher.window_exists", return_value=True), \
              mock.patch("u_agents.launcher.claim_issue") as m_claim, \
              mock.patch("u_agents.launcher.send_prompt") as m_send:
             rc = dispatch_claim(self.issue, _args())

--- a/tests/test_pr_watcher.py
+++ b/tests/test_pr_watcher.py
@@ -1,0 +1,236 @@
+import unittest
+from dataclasses import replace
+
+from u_agents.agent_runs import AgentRun
+from u_agents.pr_watcher import (
+    PrReality,
+    check_once,
+    extract_must_fix_review_comment_keys,
+    reconcile_pr_run,
+)
+
+
+def _run(**overrides):
+    base = AgentRun(
+        repository_full_name="o/r",
+        github_issue_number=12,
+        parent_branch="main",
+        branch_name="feat/12",
+        phase="pr_watching",
+        runner_id="runner-1",
+        machine_id="machine-1",
+        locked_by="runner-1@machine-1",
+        lease_until="future",
+        worktree_basename="12",
+        tmux_window="r-12",
+        pm_pane="agents:r-12.0",
+        pr_number=45,
+        pr_review_fix_rounds=0,
+        metadata={},
+    )
+    return replace(base, **overrides)
+
+
+def _reality(**overrides):
+    base = PrReality(
+        exists=True,
+        pr_number=45,
+        head_branch="feat/12",
+        merged=False,
+        ci_green=False,
+        must_fix_review_comments=False,
+    )
+    return replace(base, **overrides)
+
+
+class FakeDbClient:
+    def __init__(self, runs=None):
+        self.runs = list(runs or [])
+        self.calls = []
+
+    def list_pr_watch_runs(self):
+        return list(self.runs)
+
+    def mark_blocked(self, repo_full, issue_number, reason, *, metadata=None):
+        self.calls.append(("blocked", repo_full, issue_number, reason, metadata or {}))
+        return replace(
+            self.runs[0] if self.runs else _run(),
+            phase="blocked",
+            block_reason=reason,
+            metadata=metadata or {},
+        )
+
+    def mark_done(self, repo_full, issue_number, *, metadata=None):
+        self.calls.append(("done", repo_full, issue_number, metadata or {}))
+        return replace(
+            self.runs[0] if self.runs else _run(),
+            phase="done",
+            metadata=metadata or {},
+        )
+
+    def update_pr_fields(
+        self,
+        repo_full,
+        issue_number,
+        *,
+        pr_number=None,
+        phase=None,
+        increment_fix_rounds=False,
+        block_reason=None,
+        metadata=None,
+    ):
+        self.calls.append((
+            "update_pr_fields",
+            repo_full,
+            issue_number,
+            pr_number,
+            phase,
+            increment_fix_rounds,
+            block_reason,
+            metadata or {},
+        ))
+        run = self.runs[0] if self.runs else _run()
+        return replace(
+            run,
+            pr_number=pr_number or run.pr_number,
+            phase=phase or run.phase,
+            pr_review_fix_rounds=(
+                run.pr_review_fix_rounds + 1
+                if increment_fix_rounds
+                else run.pr_review_fix_rounds
+            ),
+            block_reason=block_reason,
+            metadata=metadata or {},
+        )
+
+
+class TestCommentClassification(unittest.TestCase):
+    def test_extracts_explicit_must_fix_comments(self):
+        keys = extract_must_fix_review_comment_keys({
+            "comments": [
+                {"id": "c1", "body": "optional cleanup"},
+                {"id": "c2", "body": "must-fix: handle missing state"},
+            ],
+            "latestReviews": [
+                {"id": "r1", "state": "COMMENTED", "body": "already addressed"},
+                {"id": "r2", "state": "CHANGES_REQUESTED", "body": "fix this"},
+            ],
+        })
+
+        self.assertEqual(keys, ("comment:c2", "latest_review:r2"))
+
+
+class TestPrWatcherTransitions(unittest.TestCase):
+    def test_missing_pr_number_blocks(self):
+        db = FakeDbClient([_run(pr_number=None)])
+        updated = reconcile_pr_run(
+            db.runs[0],
+            _reality(exists=False, pr_number=0),
+            db,
+        )
+
+        self.assertEqual(updated.phase, "blocked")
+        self.assertIn("without pr_number", db.calls[0][3])
+
+    def test_missing_pr_blocks(self):
+        db = FakeDbClient([_run()])
+        updated = reconcile_pr_run(db.runs[0], _reality(exists=False), db)
+
+        self.assertEqual(updated.phase, "blocked")
+        self.assertIn("does not exist", db.calls[0][3])
+
+    def test_head_branch_mismatch_blocks(self):
+        db = FakeDbClient([_run()])
+        updated = reconcile_pr_run(
+            db.runs[0],
+            _reality(head_branch="feat/other"),
+            db,
+        )
+
+        self.assertEqual(updated.phase, "blocked")
+        self.assertIn("does not match", db.calls[0][3])
+
+    def test_closed_unmerged_pr_blocks(self):
+        db = FakeDbClient([_run()])
+        updated = reconcile_pr_run(db.runs[0], _reality(closed=True), db)
+
+        self.assertEqual(updated.phase, "blocked")
+        self.assertIn("closed without being merged", db.calls[0][3])
+
+    def test_merged_pr_marks_done(self):
+        db = FakeDbClient([_run()])
+        updated = reconcile_pr_run(
+            db.runs[0],
+            _reality(merged=True, closed=True),
+            db,
+        )
+
+        self.assertEqual(updated.phase, "done")
+        self.assertEqual(db.calls[0][0], "done")
+
+    def test_first_must_fix_round_updates_then_assigns_fix(self):
+        db = FakeDbClient([_run(pr_review_fix_rounds=0)])
+        assignments = []
+
+        updated = reconcile_pr_run(
+            db.runs[0],
+            _reality(
+                must_fix_review_comments=True,
+                must_fix_comment_keys=("comment:c1",),
+            ),
+            db,
+            assign_fix=lambda run, reality: assignments.append(
+                (run.pr_review_fix_rounds, reality.must_fix_comment_keys)
+            ),
+        )
+
+        self.assertEqual(updated.phase, "fixing")
+        self.assertEqual(updated.pr_review_fix_rounds, 1)
+        self.assertEqual(db.calls[0][0], "update_pr_fields")
+        self.assertTrue(db.calls[0][5])
+        self.assertEqual(assignments, [(1, ("comment:c1",))])
+
+    def test_second_must_fix_round_blocks_without_assignment(self):
+        db = FakeDbClient([_run(pr_review_fix_rounds=1)])
+        assignments = []
+
+        updated = reconcile_pr_run(
+            db.runs[0],
+            _reality(must_fix_review_comments=True),
+            db,
+            assign_fix=lambda *_args: assignments.append("assigned"),
+        )
+
+        self.assertEqual(updated.phase, "blocked")
+        self.assertEqual(assignments, [])
+        self.assertEqual(db.calls[0][0], "blocked")
+
+    def test_green_without_must_fix_is_ready_to_merge(self):
+        db = FakeDbClient([_run()])
+        updated = reconcile_pr_run(db.runs[0], _reality(ci_green=True), db)
+
+        self.assertEqual(updated.phase, "ready_to_merge")
+        self.assertEqual(db.calls[0][4], "ready_to_merge")
+
+    def test_pending_ci_keeps_watching(self):
+        db = FakeDbClient([_run(phase="pr_open")])
+        updated = reconcile_pr_run(db.runs[0], _reality(ci_green=False), db)
+
+        self.assertEqual(updated.phase, "pr_watching")
+        self.assertEqual(db.calls[0][4], "pr_watching")
+
+    def test_check_once_fetches_pr_reality_for_listed_runs(self):
+        db = FakeDbClient([_run(phase="pr_open")])
+        fetched = []
+
+        updated = check_once(
+            db,
+            fetch_reality=lambda repo, pr: fetched.append((repo, pr)) or _reality(),
+        )
+
+        self.assertEqual(fetched, [("o/r", 45)])
+        self.assertEqual(updated[0].phase, "pr_watching")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr_watcher.py
+++ b/tests/test_pr_watcher.py
@@ -1,11 +1,16 @@
+import json
+import subprocess
 import unittest
 from dataclasses import replace
+from unittest import mock
 
 from u_agents.agent_runs import AgentRun
 from u_agents.pr_watcher import (
     PrReality,
+    _status_checks_green,
     check_once,
     extract_must_fix_review_comment_keys,
+    fetch_pr_reality,
     reconcile_pr_run,
 )
 
@@ -104,6 +109,56 @@ class FakeDbClient:
         )
 
 
+class TestStatusChecksGreen(unittest.TestCase):
+    """Comment 1: support both CheckRun and StatusContext rollup entries."""
+
+    def test_checkrun_completed_success_is_green(self):
+        self.assertTrue(_status_checks_green([
+            {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ]))
+
+    def test_checkrun_in_progress_is_not_green(self):
+        self.assertFalse(_status_checks_green([
+            {"__typename": "CheckRun", "status": "IN_PROGRESS", "conclusion": None},
+        ]))
+
+    def test_classic_status_context_success_is_green(self):
+        self.assertTrue(_status_checks_green([
+            {"__typename": "StatusContext", "context": "ci/circleci", "state": "SUCCESS"},
+        ]))
+
+    def test_classic_status_context_pending_is_not_green(self):
+        self.assertFalse(_status_checks_green([
+            {"__typename": "StatusContext", "context": "ci/circleci", "state": "PENDING"},
+        ]))
+
+    def test_classic_status_context_failure_is_not_green(self):
+        self.assertFalse(_status_checks_green([
+            {"__typename": "StatusContext", "context": "ci/circleci", "state": "FAILURE"},
+        ]))
+
+    def test_classic_status_context_error_is_not_green(self):
+        self.assertFalse(_status_checks_green([
+            {"__typename": "StatusContext", "context": "ci/circleci", "state": "ERROR"},
+        ]))
+
+    def test_mixed_checkrun_and_status_context_all_green(self):
+        self.assertTrue(_status_checks_green([
+            {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SKIPPED"},
+            {"__typename": "StatusContext", "context": "ci/x", "state": "SUCCESS"},
+        ]))
+
+    def test_mixed_with_failing_classic_status_is_not_green(self):
+        self.assertFalse(_status_checks_green([
+            {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"__typename": "StatusContext", "context": "ci/x", "state": "FAILURE"},
+        ]))
+
+    def test_empty_or_non_list_is_not_green(self):
+        self.assertFalse(_status_checks_green([]))
+        self.assertFalse(_status_checks_green(None))
+
+
 class TestCommentClassification(unittest.TestCase):
     def test_extracts_explicit_must_fix_comments(self):
         keys = extract_must_fix_review_comment_keys({
@@ -118,6 +173,35 @@ class TestCommentClassification(unittest.TestCase):
         })
 
         self.assertEqual(keys, ("comment:c2", "latest_review:r2"))
+
+    def test_superseded_historical_review_is_ignored(self):
+        # Comment 2: an old CHANGES_REQUESTED review that was later superseded by
+        # an APPROVED latest review must not keep the PR classified as must-fix.
+        keys = extract_must_fix_review_comment_keys({
+            "comments": [],
+            "reviews": [
+                {"id": "r1", "state": "CHANGES_REQUESTED", "body": "fix this"},
+                {"id": "r1b", "state": "APPROVED", "body": "lgtm now"},
+            ],
+            "latestReviews": [
+                {"id": "r1b", "state": "APPROVED", "body": "lgtm now"},
+            ],
+        })
+
+        self.assertEqual(keys, ())
+
+    def test_latest_changes_requested_still_classified(self):
+        keys = extract_must_fix_review_comment_keys({
+            "comments": [],
+            "reviews": [
+                {"id": "r1", "state": "APPROVED", "body": "lgtm"},
+            ],
+            "latestReviews": [
+                {"id": "r2", "state": "CHANGES_REQUESTED", "body": "needs work"},
+            ],
+        })
+
+        self.assertEqual(keys, ("latest_review:r2",))
 
 
 class TestPrWatcherTransitions(unittest.TestCase):
@@ -230,6 +314,89 @@ class TestPrWatcherTransitions(unittest.TestCase):
 
         self.assertEqual(fetched, [("o/r", 45)])
         self.assertEqual(updated[0].phase, "pr_watching")
+
+    def test_check_once_defers_run_on_transient_fetch_error(self):
+        # Comment 3: a transient fetch failure must not block the run; it is
+        # skipped this pass and retried later, never marked blocked.
+        db = FakeDbClient([_run(phase="pr_open")])
+
+        def boom(_repo, _pr):
+            raise RuntimeError("transient github outage")
+
+        updated = check_once(db, fetch_reality=boom)
+
+        self.assertEqual(updated, [])
+        self.assertEqual(db.calls, [])
+
+
+class TestFetchPrReality(unittest.TestCase):
+    """Comment 3: definitive not-found vs transient/parse failures."""
+
+    @staticmethod
+    def _completed(returncode=0, stdout="", stderr=""):
+        return subprocess.CompletedProcess(
+            args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr,
+        )
+
+    def test_definitive_not_found_returns_exists_false(self):
+        proc = self._completed(
+            returncode=1,
+            stderr="GraphQL: Could not resolve to a PullRequest with the number of 999.",
+        )
+        with mock.patch("u_agents.pr_watcher._run", return_value=proc):
+            reality = fetch_pr_reality("o/r", 999)
+
+        self.assertFalse(reality.exists)
+        self.assertEqual(reality.pr_number, 999)
+
+    def test_transient_failure_raises_runtime_error(self):
+        proc = self._completed(
+            returncode=1,
+            stderr="error connecting to api.github.com: dial tcp: i/o timeout",
+        )
+        with mock.patch("u_agents.pr_watcher._run", return_value=proc):
+            with self.assertRaises(RuntimeError):
+                fetch_pr_reality("o/r", 45)
+
+    def test_dns_resolution_failure_is_transient_not_absence(self):
+        # "Could not resolve host" is a DNS/network error, not a missing PR.
+        proc = self._completed(
+            returncode=1, stderr="Could not resolve host: api.github.com",
+        )
+        with mock.patch("u_agents.pr_watcher._run", return_value=proc):
+            with self.assertRaises(RuntimeError):
+                fetch_pr_reality("o/r", 45)
+
+    def test_malformed_json_raises_runtime_error(self):
+        proc = self._completed(returncode=0, stdout="<html>500</html>")
+        with mock.patch("u_agents.pr_watcher._run", return_value=proc):
+            with self.assertRaises(RuntimeError):
+                fetch_pr_reality("o/r", 45)
+
+    def test_valid_payload_parses_into_reality(self):
+        payload = json.dumps({
+            "number": 45,
+            "headRefName": "feat/12",
+            "state": "OPEN",
+            "merged": False,
+            "statusCheckRollup": [
+                {"__typename": "StatusContext", "context": "ci", "state": "SUCCESS"},
+            ],
+            "reviewDecision": None,
+            "comments": [],
+            "latestReviews": [],
+        })
+        with mock.patch(
+            "u_agents.pr_watcher._run",
+            return_value=self._completed(returncode=0, stdout=payload),
+        ):
+            reality = fetch_pr_reality("o/r", 45)
+
+        self.assertTrue(reality.exists)
+        self.assertEqual(reality.pr_number, 45)
+        self.assertEqual(reality.head_branch, "feat/12")
+        self.assertTrue(reality.ci_green)
+        self.assertFalse(reality.must_fix_review_comments)
 
 
 if __name__ == "__main__":

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest import mock
 
 from u_agents.contract import RepoConfig
+from u_agents.agent_runs import AgentRun
 from u_agents import watchdog
 from u_agents.watchdog import (
     DEFAULT_STATE_DIR,
@@ -25,6 +26,43 @@ class FakeClock:
     def __call__(self):
         self.t += 1.0
         return self.t
+
+
+def _run_row(repo_full="uuta/u", issue_number=5, phase="pm_started",
+             tmux_window="u-5", pm_pane="agents:u-5.0", lease_until="past"):
+    return AgentRun(
+        repository_full_name=repo_full,
+        github_issue_number=issue_number,
+        parent_branch="main",
+        branch_name=f"feat/{issue_number}",
+        phase=phase,
+        runner_id="runner-1",
+        machine_id="machine-1",
+        locked_by="runner-1@machine-1",
+        lease_until=lease_until,
+        worktree_basename=str(issue_number),
+        tmux_window=tmux_window,
+        pm_pane=pm_pane,
+    )
+
+
+class FakeDbClient:
+    def __init__(self, active=None, stale=None):
+        self.active = list(active or [])
+        self.stale = list(stale or [])
+        self.observations = []
+
+    def list_active_runs(self):
+        return list(self.active)
+
+    def list_stale_runs(self):
+        return list(self.stale)
+
+    def record_observation(self, repo_full, issue_number, observation):
+        self.observations.append((repo_full, issue_number, observation))
+
+    def close(self):
+        return None
 
 
 class TestDefaultStatePath(unittest.TestCase):
@@ -73,6 +111,8 @@ class TestWatchdogMainStateDir(unittest.TestCase):
                 return_value=Path("/dev/null"),
             ),
             mock.patch("u_agents.watchdog.load_config", return_value=[]),
+            mock.patch("u_agents.watchdog.AgentRunsClient.from_env",
+                       return_value=FakeDbClient()),
             mock.patch("u_agents.watchdog.check_once") as check_once_mock,
         ):
             rc = watchdog_main(["--once", "--state-dir", d])
@@ -211,6 +251,74 @@ class TestCheckOnce(unittest.TestCase):
             comment=comment, now=self.clock,
         )
         self.assertEqual(attempts, [self.window])
+
+    def test_db_backed_lookup_pings_stale_run_after_stall(self):
+        db = FakeDbClient(active=[], stale=[_run_row()])
+        pings = []
+
+        def list_windows():
+            return [self.window]
+
+        def capture(_w):
+            return "idle"
+
+        def ping(w, _dry):
+            pings.append(w)
+
+        check_once(
+            [self.repo], self.state_file, stall_checks=1, dry_run=False,
+            list_windows=list_windows, capture=capture, ping=ping,
+            comment=lambda *_args: None, now=self.clock, db_client=db,
+            verify_run=lambda _run: True,
+        )
+        check_once(
+            [self.repo], self.state_file, stall_checks=1, dry_run=False,
+            list_windows=list_windows, capture=capture, ping=ping,
+            comment=lambda *_args: None, now=self.clock, db_client=db,
+            verify_run=lambda _run: True,
+        )
+
+        self.assertEqual(pings, [self.window])
+        self.assertEqual(db.observations[0][2]["watchdog"], "stale_lease")
+
+    def test_missing_db_tmux_window_records_mismatch_without_pane_action(self):
+        db = FakeDbClient(active=[_run_row(tmux_window="u-5")])
+        captures = []
+        pings = []
+
+        check_once(
+            [self.repo], self.state_file, stall_checks=1, dry_run=False,
+            list_windows=lambda: [],
+            capture=lambda w: captures.append(w) or "idle",
+            ping=lambda w, _dry: pings.append(w),
+            comment=lambda *_args: None,
+            now=self.clock,
+            db_client=db,
+            verify_run=lambda _run: True,
+        )
+
+        self.assertEqual(captures, [])
+        self.assertEqual(pings, [])
+        self.assertEqual(db.observations[0][2]["watchdog"], "tmux_window_missing")
+
+    def test_failed_github_verification_records_observation(self):
+        db = FakeDbClient(active=[_run_row()])
+
+        check_once(
+            [self.repo], self.state_file, stall_checks=1, dry_run=False,
+            list_windows=lambda: [self.window],
+            capture=lambda _w: "idle",
+            ping=lambda *_args: None,
+            comment=lambda *_args: None,
+            now=self.clock,
+            db_client=db,
+            verify_run=lambda _run: False,
+        )
+
+        self.assertEqual(
+            db.observations[0][2]["watchdog"],
+            "github_issue_verification_failed",
+        )
 
 
 class TestCheckOnceUnknownRepo(unittest.TestCase):

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -345,6 +345,71 @@ class TestCheckOnce(unittest.TestCase):
         self.assertEqual(db.observations, [])
         self.assertEqual(pings, [])
 
+    def test_transient_verification_preserves_live_window_state(self):
+        # Manager blocker: a transient verify_run failure must defer the run
+        # without letting the cleanup sweep delete the live window's stall
+        # state. Otherwise a sustained outage repeatedly resets the counters.
+        save_state(
+            self.state_file,
+            {"u-5": WindowState(last_hash="h", unchanged_checks=2,
+                                pinged=False, stall_comment_posted=False,
+                                last_update=10.0)},
+        )
+        db = FakeDbClient(active=[_run_row(tmux_window="u-5")])
+        captures = []
+        pings = []
+
+        def verify(_run):
+            raise RuntimeError("transient")
+
+        check_once(
+            [self.repo], self.state_file, stall_checks=1, dry_run=False,
+            list_windows=lambda: [self.window],
+            capture=lambda w: captures.append(w) or "idle",
+            ping=lambda w, _dry: pings.append(w),
+            comment=lambda *_args: None,
+            now=self.clock,
+            db_client=db,
+            verify_run=verify,
+        )
+
+        state = load_state(self.state_file)
+        self.assertIn("u-5", state)
+        self.assertEqual(state["u-5"].last_hash, "h")
+        self.assertEqual(state["u-5"].unchanged_checks, 2)
+        self.assertFalse(state["u-5"].pinged)
+        self.assertFalse(state["u-5"].stall_comment_posted)
+        self.assertEqual(state["u-5"].last_update, 10.0)
+        # No pane action this pass: state counters are left untouched.
+        self.assertEqual(captures, [])
+        self.assertEqual(pings, [])
+        self.assertEqual(db.observations, [])
+
+    def test_transient_verification_does_not_preserve_gone_window_state(self):
+        # A deferred run whose tmux window is no longer live must not pin stale
+        # local state; genuinely gone windows still expire via cleanup.
+        save_state(
+            self.state_file,
+            {"u-5": WindowState(last_hash="h", unchanged_checks=2)},
+        )
+        db = FakeDbClient(active=[_run_row(tmux_window="u-5")])
+
+        def verify(_run):
+            raise RuntimeError("transient")
+
+        check_once(
+            [self.repo], self.state_file, stall_checks=1, dry_run=False,
+            list_windows=lambda: [],  # window no longer live
+            capture=lambda _w: "idle",
+            ping=lambda *_args: None,
+            comment=lambda *_args: None,
+            now=self.clock,
+            db_client=db,
+            verify_run=verify,
+        )
+
+        self.assertEqual(load_state(self.state_file), {})
+
 
 class TestGithubIssueVerification(unittest.TestCase):
     """Comment 5: distinguish definitive vs transient issue verification."""

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,4 +1,6 @@
+import json
 import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -319,6 +321,96 @@ class TestCheckOnce(unittest.TestCase):
             db.observations[0][2]["watchdog"],
             "github_issue_verification_failed",
         )
+
+    def test_transient_verification_error_is_not_recorded_as_metadata(self):
+        # Comment 5: a transient verification failure must be retried by the
+        # outer loop, not stored as github_issue_verification_failed metadata.
+        db = FakeDbClient(active=[_run_row()])
+        pings = []
+
+        def verify(_run):
+            raise RuntimeError("transient network error")
+
+        check_once(
+            [self.repo], self.state_file, stall_checks=1, dry_run=False,
+            list_windows=lambda: [self.window],
+            capture=lambda _w: "idle",
+            ping=lambda w, _dry: pings.append(w),
+            comment=lambda *_args: None,
+            now=self.clock,
+            db_client=db,
+            verify_run=verify,
+        )
+
+        self.assertEqual(db.observations, [])
+        self.assertEqual(pings, [])
+
+
+class TestGithubIssueVerification(unittest.TestCase):
+    """Comment 5: distinguish definitive vs transient issue verification."""
+
+    @staticmethod
+    def _completed(returncode=0, stdout="", stderr=""):
+        return subprocess.CompletedProcess(
+            args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr,
+        )
+
+    def test_transient_error_raises_runtime_error(self):
+        proc = self._completed(
+            returncode=1, stderr="error connecting to api.github.com: timeout",
+        )
+        with mock.patch("u_agents.watchdog.subprocess.run", return_value=proc):
+            with self.assertRaises(RuntimeError):
+                watchdog.github_issue_allows_watchdog_action(_run_row())
+
+    def test_not_found_returns_false(self):
+        proc = self._completed(
+            returncode=1,
+            stderr="GraphQL: Could not resolve to an Issue with the number of 5.",
+        )
+        with mock.patch("u_agents.watchdog.subprocess.run", return_value=proc):
+            self.assertFalse(
+                watchdog.github_issue_allows_watchdog_action(_run_row())
+            )
+
+    def test_dns_resolution_failure_is_transient_not_absence(self):
+        # "Could not resolve host" is a DNS/network error, not a missing issue.
+        proc = self._completed(
+            returncode=1, stderr="Could not resolve host: api.github.com",
+        )
+        with mock.patch("u_agents.watchdog.subprocess.run", return_value=proc):
+            with self.assertRaises(RuntimeError):
+                watchdog.github_issue_allows_watchdog_action(_run_row())
+
+    def test_malformed_json_raises_runtime_error(self):
+        proc = self._completed(returncode=0, stdout="<html>502</html>")
+        with mock.patch("u_agents.watchdog.subprocess.run", return_value=proc):
+            with self.assertRaises(RuntimeError):
+                watchdog.github_issue_allows_watchdog_action(_run_row())
+
+    def test_closed_issue_returns_false(self):
+        proc = self._completed(
+            returncode=0, stdout=json.dumps({"state": "CLOSED", "labels": []}),
+        )
+        with mock.patch("u_agents.watchdog.subprocess.run", return_value=proc):
+            self.assertFalse(
+                watchdog.github_issue_allows_watchdog_action(_run_row())
+            )
+
+    def test_open_issue_with_in_progress_label_is_allowed(self):
+        from u_agents.contract import LABEL_IN_PROGRESS
+        proc = self._completed(
+            returncode=0,
+            stdout=json.dumps(
+                {"state": "OPEN", "labels": [{"name": LABEL_IN_PROGRESS}]}
+            ),
+        )
+        with mock.patch("u_agents.watchdog.subprocess.run", return_value=proc):
+            self.assertTrue(
+                watchdog.github_issue_allows_watchdog_action(
+                    _run_row(phase="engineering")
+                )
+            )
 
 
 class TestCheckOnceUnknownRepo(unittest.TestCase):

--- a/u_agents/README.md
+++ b/u_agents/README.md
@@ -1,14 +1,16 @@
 # u_agents/
 
-v0.1 local agent runner. See [`docs/u-agents.md`](../docs/u-agents.md) for the
+v0.2 DB-backed local agent runner. See [`docs/u-agents.md`](../docs/u-agents.md) for the
 full design, configuration, and command reference.
 
 Layout:
 
 - `contract.py` — config + naming primitives.
 - `control_plane.py` — v0.2 pure DB-control-plane constants and decisions.
+- `agent_runs.py` — PostgreSQL `agent_runs` runtime access layer.
 - `launcher.py` — short-lived starter/resumer (`python3 -m u_agents.launcher`).
 - `watchdog.py` — stall detector (`python3 -m u_agents.watchdog`).
+- `pr_watcher.py` — DB-backed PR phase watcher (`python3 -m u_agents.pr_watcher`).
 - `prompts/pm.md` — PM prompt template sent into the tmux PM pane.
 - `compose.yml` — local PostgreSQL 17 for v0.2 control-plane development.
 - `db/` — `agent_runs` schema and contract docs.
@@ -18,8 +20,9 @@ Reviewer handoff is explicit: each issue worktree uses
 `blocked`. See [`docs/u-agents.md`](../docs/u-agents.md#reviewer-result-contract).
 
 The v0.2 DB control-plane contract is documented in
-[`db/README.md`](db/README.md). Current launcher behavior remains usable
-without a database until DB runtime integration is added.
+[`db/README.md`](db/README.md). Live runtime paths require
+`U_AGENTS_DATABASE_URL`, `U_AGENTS_RUNNER_ID`, `U_AGENTS_MACHINE_ID`, local
+Postgres, and `psycopg`; unit tests and `--help` paths do not import psycopg.
 
 Tests live under `../tests/`. Run with:
 

--- a/u_agents/agent_runs.py
+++ b/u_agents/agent_runs.py
@@ -495,6 +495,12 @@ class AgentRunsClient:
         with self.conn.cursor() as cur:
             cur.execute(sql, params)
             rows = cur.fetchall()
+        # A bare SELECT opens a transaction in PostgreSQL; commit so the
+        # connection does not linger 'idle in transaction' across loop passes
+        # (mirrors `_fetch_one`).
+        commit = getattr(self.conn, "commit", None)
+        if commit is not None:
+            commit()
         return rows
 
     def _require_row(self, sql: str, params: Mapping[str, Any]) -> AgentRun:

--- a/u_agents/agent_runs.py
+++ b/u_agents/agent_runs.py
@@ -1,0 +1,504 @@
+"""Runtime access layer for the PostgreSQL ``agent_runs`` table."""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Sequence
+
+from u_agents.contract import (
+    ConfigError,
+    REVIEW_RESULT_RELATIVE_PATH,
+    RepoConfig,
+    pm_pane_target,
+    tmux_window_name,
+)
+from u_agents.control_plane import (
+    AGENT_RUN_PHASES,
+    RunnerIdentity,
+    database_url_from_env,
+    load_runner_identity,
+    validate_identity_value,
+    validate_worktree_basename,
+)
+
+
+ACTIVE_PHASES = (
+    "claimed",
+    "pm_started",
+    "engineering",
+    "reviewing",
+    "fixing",
+    "pr_open",
+    "pr_watching",
+    "ready_to_merge",
+)
+TERMINAL_PHASES = ("blocked", "done", "cancelled")
+
+_REPOSITORY_RE = re.compile(r"^[^/\s]+/[^/\s]+$")
+
+
+@dataclass(frozen=True)
+class AgentRun:
+    repository_full_name: str
+    github_issue_number: int
+    parent_branch: str
+    branch_name: str
+    phase: str
+    runner_id: str
+    machine_id: str
+    locked_by: str | None
+    lease_until: Any
+    worktree_basename: str
+    tmux_window: str
+    pm_pane: str | None = None
+    pr_number: int | None = None
+    pr_review_fix_rounds: int = 0
+    block_reason: str | None = None
+    metadata: Mapping[str, Any] | None = None
+
+    @classmethod
+    def from_row(cls, row: Mapping[str, Any]) -> "AgentRun":
+        return cls(
+            repository_full_name=str(row["repository_full_name"]),
+            github_issue_number=int(row["github_issue_number"]),
+            parent_branch=str(row["parent_branch"]),
+            branch_name=str(row["branch_name"]),
+            phase=str(row["phase"]),
+            runner_id=str(row["runner_id"]),
+            machine_id=str(row["machine_id"]),
+            locked_by=row.get("locked_by"),
+            lease_until=row.get("lease_until"),
+            worktree_basename=str(row["worktree_basename"]),
+            tmux_window=str(row["tmux_window"]),
+            pm_pane=row.get("pm_pane"),
+            pr_number=row.get("pr_number"),
+            pr_review_fix_rounds=int(row.get("pr_review_fix_rounds") or 0),
+            block_reason=row.get("block_reason"),
+            metadata=row.get("metadata") or {},
+        )
+
+
+@dataclass(frozen=True)
+class ClaimPayload:
+    repository_full_name: str
+    github_issue_number: int
+    parent_branch: str
+    branch_name: str
+    runner_id: str
+    machine_id: str
+    locked_by: str
+    lease_until: datetime
+    worktree_basename: str
+    tmux_window: str
+    review_result_relative_path: str = REVIEW_RESULT_RELATIVE_PATH
+    phase: str = "claimed"
+
+
+def validate_repository_full_name(value: str) -> str:
+    if not isinstance(value, str) or not _REPOSITORY_RE.match(value):
+        raise ValueError("repository_full_name must be owner/name with no whitespace")
+    return value
+
+
+def validate_issue_number(value: int) -> int:
+    if not isinstance(value, int) or value <= 0:
+        raise ValueError("github_issue_number must be a positive integer")
+    return value
+
+
+def validate_nonempty_nowhitespace(value: str, field: str) -> str:
+    if not isinstance(value, str) or value.strip() == "":
+        raise ValueError(f"{field} must be non-empty")
+    if any(ch.isspace() for ch in value):
+        raise ValueError(f"{field} must not contain whitespace")
+    return value
+
+
+def validate_runner_identity_field(value: str, field: str) -> str:
+    value = validate_nonempty_nowhitespace(value, field)
+    validate_identity_value(value, field)
+    return value
+
+
+def validate_phase(value: str) -> str:
+    if value not in AGENT_RUN_PHASES:
+        raise ValueError(f"phase must be one of: {', '.join(AGENT_RUN_PHASES)}")
+    return value
+
+
+def validate_metadata(metadata: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    if metadata is None:
+        return {}
+    if not isinstance(metadata, Mapping):
+        raise ValueError("metadata must be a mapping/object")
+    json.dumps(dict(metadata))
+    return metadata
+
+
+def build_claim_payload(
+    repo: RepoConfig,
+    issue_number: int,
+    branch: str,
+    identity: RunnerIdentity,
+    *,
+    lease_seconds: int = 900,
+    now: datetime | None = None,
+) -> ClaimPayload:
+    base = now or datetime.now(timezone.utc)
+    if lease_seconds <= 0:
+        raise ValueError("lease_seconds must be positive")
+    return ClaimPayload(
+        repository_full_name=validate_repository_full_name(repo.full_name),
+        github_issue_number=validate_issue_number(issue_number),
+        parent_branch=validate_nonempty_nowhitespace(
+            repo.default_branch, "parent_branch"
+        ),
+        branch_name=validate_nonempty_nowhitespace(branch, "branch_name"),
+        runner_id=validate_runner_identity_field(identity.runner_id, "runner_id"),
+        machine_id=validate_runner_identity_field(identity.machine_id, "machine_id"),
+        locked_by=validate_nonempty_nowhitespace(identity.lock_owner, "locked_by"),
+        lease_until=base + timedelta(seconds=lease_seconds),
+        worktree_basename=validate_worktree_basename(str(issue_number)),
+        tmux_window=validate_nonempty_nowhitespace(
+            tmux_window_name(repo, issue_number), "tmux_window"
+        ),
+    )
+
+
+def _row_columns() -> str:
+    return (
+        "repository_full_name, github_issue_number, parent_branch, branch_name, "
+        "phase, runner_id, machine_id, locked_by, lease_until, "
+        "worktree_basename, tmux_window, pm_pane, pr_number, "
+        "pr_review_fix_rounds, block_reason, metadata"
+    )
+
+
+class AgentRunsClient:
+    def __init__(self, conn: Any, identity: RunnerIdentity):
+        self.conn = conn
+        self.identity = identity
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, object] | None = None) -> "AgentRunsClient":
+        url = database_url_from_env(env)
+        identity = load_runner_identity(env)
+        try:
+            import psycopg
+            from psycopg.rows import dict_row
+        except ModuleNotFoundError as e:
+            raise ConfigError(
+                "psycopg is required for u_agents DB runtime access; "
+                "install it with `python3 -m pip install 'psycopg[binary]'`"
+            ) from e
+        return cls(psycopg.connect(url, row_factory=dict_row), identity)
+
+    def close(self) -> None:
+        close = getattr(self.conn, "close", None)
+        if close is not None:
+            close()
+
+    def acquire_claim(self, payload: ClaimPayload) -> AgentRun:
+        self._validate_claim_payload(payload)
+        sql = f"""
+            INSERT INTO agent_runs (
+                repository_full_name, github_issue_number, parent_branch,
+                branch_name, phase, runner_id, machine_id, locked_by,
+                lease_until, worktree_basename, tmux_window,
+                review_result_relative_path, metadata
+            ) VALUES (
+                %(repository_full_name)s, %(github_issue_number)s,
+                %(parent_branch)s, %(branch_name)s, %(phase)s,
+                %(runner_id)s, %(machine_id)s, %(locked_by)s,
+                %(lease_until)s, %(worktree_basename)s, %(tmux_window)s,
+                %(review_result_relative_path)s, '{{}}'::jsonb
+            )
+            ON CONFLICT (repository_full_name, github_issue_number) DO UPDATE
+            SET parent_branch = EXCLUDED.parent_branch,
+                branch_name = EXCLUDED.branch_name,
+                phase = 'claimed',
+                runner_id = EXCLUDED.runner_id,
+                machine_id = EXCLUDED.machine_id,
+                locked_by = EXCLUDED.locked_by,
+                lease_until = EXCLUDED.lease_until,
+                worktree_basename = EXCLUDED.worktree_basename,
+                tmux_window = EXCLUDED.tmux_window,
+                pm_pane = NULL,
+                block_reason = NULL,
+                review_result_relative_path = EXCLUDED.review_result_relative_path,
+                metadata = agent_runs.metadata || '{{"reclaimed": true}}'::jsonb
+            WHERE agent_runs.lease_until IS NULL
+               OR agent_runs.lease_until < now()
+               OR agent_runs.locked_by = EXCLUDED.locked_by
+               OR agent_runs.phase IN ('blocked', 'done', 'cancelled')
+            RETURNING {_row_columns()}
+        """
+        row = self._fetch_one(sql, payload.__dict__)
+        if row is None:
+            raise RuntimeError(
+                "agent_runs claim lease is held by another runner for "
+                f"{payload.repository_full_name}#{payload.github_issue_number}"
+            )
+        return AgentRun.from_row(row)
+
+    def update_phase(
+        self,
+        repository_full_name: str,
+        github_issue_number: int,
+        phase: str,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+        block_reason: str | None = None,
+        clear_lease: bool = False,
+    ) -> AgentRun:
+        validate_repository_full_name(repository_full_name)
+        validate_issue_number(github_issue_number)
+        validate_phase(phase)
+        validate_metadata(metadata)
+        if phase == "blocked" and (block_reason is None or block_reason.strip() == ""):
+            raise ValueError("block_reason is required when phase is blocked")
+        sql = f"""
+            UPDATE agent_runs
+            SET phase = %(phase)s,
+                block_reason = %(block_reason)s,
+                locked_by = CASE WHEN %(clear_lease)s THEN NULL ELSE locked_by END,
+                lease_until = CASE WHEN %(clear_lease)s THEN NULL ELSE lease_until END,
+                metadata = metadata || %(metadata)s::jsonb
+            WHERE repository_full_name = %(repository_full_name)s
+              AND github_issue_number = %(github_issue_number)s
+            RETURNING {_row_columns()}
+        """
+        return self._require_row(sql, {
+            "repository_full_name": repository_full_name,
+            "github_issue_number": github_issue_number,
+            "phase": phase,
+            "block_reason": block_reason,
+            "clear_lease": clear_lease,
+            "metadata": json.dumps(dict(metadata or {})),
+        })
+
+    def update_tmux_coordinates(
+        self,
+        repository_full_name: str,
+        github_issue_number: int,
+        *,
+        tmux_window: str,
+        pm_pane: str | None,
+        phase: str = "pm_started",
+    ) -> AgentRun:
+        validate_repository_full_name(repository_full_name)
+        validate_issue_number(github_issue_number)
+        validate_nonempty_nowhitespace(tmux_window, "tmux_window")
+        if pm_pane is not None:
+            validate_nonempty_nowhitespace(pm_pane, "pm_pane")
+        validate_phase(phase)
+        sql = f"""
+            UPDATE agent_runs
+            SET phase = %(phase)s,
+                tmux_window = %(tmux_window)s,
+                pm_pane = %(pm_pane)s
+            WHERE repository_full_name = %(repository_full_name)s
+              AND github_issue_number = %(github_issue_number)s
+            RETURNING {_row_columns()}
+        """
+        return self._require_row(sql, {
+            "repository_full_name": repository_full_name,
+            "github_issue_number": github_issue_number,
+            "phase": phase,
+            "tmux_window": tmux_window,
+            "pm_pane": pm_pane,
+        })
+
+    def mark_pm_started(self, run: AgentRun) -> AgentRun:
+        return self.update_tmux_coordinates(
+            run.repository_full_name,
+            run.github_issue_number,
+            tmux_window=run.tmux_window,
+            pm_pane=pm_pane_target(run.tmux_window),
+            phase="pm_started",
+        )
+
+    def update_pr_fields(
+        self,
+        repository_full_name: str,
+        github_issue_number: int,
+        *,
+        pr_number: int | None = None,
+        phase: str | None = None,
+        increment_fix_rounds: bool = False,
+        block_reason: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> AgentRun:
+        validate_repository_full_name(repository_full_name)
+        validate_issue_number(github_issue_number)
+        if pr_number is not None and pr_number <= 0:
+            raise ValueError("pr_number must be positive when set")
+        if phase is not None:
+            validate_phase(phase)
+        validate_metadata(metadata)
+        if phase == "blocked" and (block_reason is None or block_reason.strip() == ""):
+            raise ValueError("block_reason is required when phase is blocked")
+        sql = f"""
+            UPDATE agent_runs
+            SET pr_number = COALESCE(%(pr_number)s, pr_number),
+                phase = COALESCE(%(phase)s, phase),
+                pr_review_fix_rounds = pr_review_fix_rounds
+                    + CASE WHEN %(increment_fix_rounds)s THEN 1 ELSE 0 END,
+                block_reason = %(block_reason)s,
+                metadata = metadata || %(metadata)s::jsonb
+            WHERE repository_full_name = %(repository_full_name)s
+              AND github_issue_number = %(github_issue_number)s
+            RETURNING {_row_columns()}
+        """
+        return self._require_row(sql, {
+            "repository_full_name": repository_full_name,
+            "github_issue_number": github_issue_number,
+            "pr_number": pr_number,
+            "phase": phase,
+            "increment_fix_rounds": increment_fix_rounds,
+            "block_reason": block_reason,
+            "metadata": json.dumps(dict(metadata or {})),
+        })
+
+    def record_observation(
+        self,
+        repository_full_name: str,
+        github_issue_number: int,
+        observation: Mapping[str, Any],
+    ) -> AgentRun:
+        return self.update_phase(
+            repository_full_name,
+            github_issue_number,
+            phase=self.get_run(repository_full_name, github_issue_number).phase,
+            metadata={"observations": dict(observation)},
+        )
+
+    def mark_blocked(
+        self,
+        repository_full_name: str,
+        github_issue_number: int,
+        reason: str,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> AgentRun:
+        return self.update_phase(
+            repository_full_name,
+            github_issue_number,
+            "blocked",
+            block_reason=reason,
+            metadata=metadata,
+            clear_lease=True,
+        )
+
+    def mark_done(
+        self,
+        repository_full_name: str,
+        github_issue_number: int,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> AgentRun:
+        return self.update_phase(
+            repository_full_name,
+            github_issue_number,
+            "done",
+            metadata=metadata,
+            clear_lease=True,
+        )
+
+    def cancel_run(
+        self,
+        repository_full_name: str,
+        github_issue_number: int,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> AgentRun:
+        return self.update_phase(
+            repository_full_name,
+            github_issue_number,
+            "cancelled",
+            metadata=metadata,
+            clear_lease=True,
+        )
+
+    def get_run(self, repository_full_name: str, github_issue_number: int) -> AgentRun:
+        validate_repository_full_name(repository_full_name)
+        validate_issue_number(github_issue_number)
+        sql = f"""
+            SELECT {_row_columns()}
+            FROM agent_runs
+            WHERE repository_full_name = %(repository_full_name)s
+              AND github_issue_number = %(github_issue_number)s
+        """
+        return self._require_row(sql, {
+            "repository_full_name": repository_full_name,
+            "github_issue_number": github_issue_number,
+        })
+
+    def list_active_runs(self) -> list[AgentRun]:
+        sql = f"""
+            SELECT {_row_columns()}
+            FROM agent_runs
+            WHERE phase = ANY(%(phases)s)
+            ORDER BY updated_at ASC
+        """
+        return [AgentRun.from_row(r) for r in self._fetch_all(sql, {"phases": list(ACTIVE_PHASES)})]
+
+    def list_stale_runs(self) -> list[AgentRun]:
+        sql = f"""
+            SELECT {_row_columns()}
+            FROM agent_runs
+            WHERE phase = ANY(%(phases)s)
+              AND lease_until IS NOT NULL
+              AND lease_until < now()
+            ORDER BY lease_until ASC
+        """
+        return [AgentRun.from_row(r) for r in self._fetch_all(sql, {"phases": list(ACTIVE_PHASES)})]
+
+    def list_pr_watch_runs(self) -> list[AgentRun]:
+        sql = f"""
+            SELECT {_row_columns()}
+            FROM agent_runs
+            WHERE phase IN ('pr_open', 'pr_watching', 'ready_to_merge')
+              AND pr_number IS NOT NULL
+            ORDER BY updated_at ASC
+        """
+        return [AgentRun.from_row(r) for r in self._fetch_all(sql, {})]
+
+    def _validate_claim_payload(self, payload: ClaimPayload) -> None:
+        validate_repository_full_name(payload.repository_full_name)
+        validate_issue_number(payload.github_issue_number)
+        validate_nonempty_nowhitespace(payload.parent_branch, "parent_branch")
+        validate_nonempty_nowhitespace(payload.branch_name, "branch_name")
+        validate_runner_identity_field(payload.runner_id, "runner_id")
+        validate_runner_identity_field(payload.machine_id, "machine_id")
+        validate_nonempty_nowhitespace(payload.locked_by, "locked_by")
+        validate_worktree_basename(payload.worktree_basename)
+        validate_nonempty_nowhitespace(payload.tmux_window, "tmux_window")
+        validate_phase(payload.phase)
+        if payload.review_result_relative_path != REVIEW_RESULT_RELATIVE_PATH:
+            raise ValueError(
+                "review_result_relative_path must be tmp/review-result.json"
+            )
+
+    def _fetch_one(self, sql: str, params: Mapping[str, Any]) -> Mapping[str, Any] | None:
+        with self.conn.cursor() as cur:
+            cur.execute(sql, params)
+            row = cur.fetchone()
+        commit = getattr(self.conn, "commit", None)
+        if commit is not None:
+            commit()
+        return row
+
+    def _fetch_all(self, sql: str, params: Mapping[str, Any]) -> Sequence[Mapping[str, Any]]:
+        with self.conn.cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+        return rows
+
+    def _require_row(self, sql: str, params: Mapping[str, Any]) -> AgentRun:
+        row = self._fetch_one(sql, params)
+        if row is None:
+            raise RuntimeError("agent_runs row was not found")
+        return AgentRun.from_row(row)

--- a/u_agents/config/repositories.example.yml
+++ b/u_agents/config/repositories.example.yml
@@ -1,4 +1,4 @@
-# Local target repositories for the v0.1 agent runner.
+# Local target repositories for the v0.2 DB-backed agent runner.
 #
 # Each entry:
 #   full_name:       GitHub repo (owner/name)

--- a/u_agents/control_plane.py
+++ b/u_agents/control_plane.py
@@ -32,6 +32,19 @@ PR_REVIEW_FIX_MAX_ROUNDS = 1
 ENV_DATABASE_URL = "U_AGENTS_DATABASE_URL"
 ENV_RUNNER_ID = "U_AGENTS_RUNNER_ID"
 ENV_MACHINE_ID = "U_AGENTS_MACHINE_ID"
+_PLACEHOLDER_IDENTITIES = {
+    "runner",
+    "runner-id",
+    "runner_id",
+    "machine",
+    "machine-id",
+    "machine_id",
+    "placeholder",
+    "changeme",
+    "change-me",
+    "todo",
+    "example",
+}
 
 
 @dataclass(frozen=True)
@@ -58,6 +71,14 @@ def _require_env(env: Mapping[str, object], name: str) -> str:
     return value
 
 
+def validate_identity_value(value: str, name: str) -> str:
+    if not isinstance(value, str) or value.strip() == "":
+        raise ConfigError(f"{name} is required and must be non-empty")
+    if value.strip().lower() in _PLACEHOLDER_IDENTITIES:
+        raise ConfigError(f"{name} must not be a placeholder identity")
+    return value
+
+
 def database_url_from_env(env: Mapping[str, object] | None = None) -> str:
     """Read and validate the PostgreSQL connection URL from environment."""
     url = _require_env(os.environ if env is None else env, ENV_DATABASE_URL)
@@ -76,8 +97,12 @@ def load_runner_identity(env: Mapping[str, object] | None = None) -> RunnerIdent
     """
     source = os.environ if env is None else env
     return RunnerIdentity(
-        runner_id=_require_env(source, ENV_RUNNER_ID),
-        machine_id=_require_env(source, ENV_MACHINE_ID),
+        runner_id=validate_identity_value(
+            _require_env(source, ENV_RUNNER_ID), ENV_RUNNER_ID,
+        ),
+        machine_id=validate_identity_value(
+            _require_env(source, ENV_MACHINE_ID), ENV_MACHINE_ID,
+        ),
     )
 
 

--- a/u_agents/db/README.md
+++ b/u_agents/db/README.md
@@ -33,6 +33,17 @@ Default local development URL:
 postgresql://u_agents:u_agents_dev_password@127.0.0.1:54329/u_agents
 ```
 
+## Python runtime dependency
+
+The runtime DB client imports `psycopg` only when opening a real database
+connection. Unit tests and `--help` paths do not require it. Install it in the
+Python environment that runs launchd/mise tasks before using the live DB-backed
+launcher, watchdog, or PR watcher:
+
+```sh
+python3 -m pip install 'psycopg[binary]'
+```
+
 ## Required runner configuration
 
 Runners must read these values from configuration or environment. Agents must
@@ -40,9 +51,9 @@ not invent placeholder identities.
 
 | Name | Meaning | Validation |
 | ---- | ------- | ---------- |
-| `U_AGENTS_DATABASE_URL` | PostgreSQL connection URL. | Required, non-empty. |
-| `U_AGENTS_RUNNER_ID` | Stable runner process/service identity. | Required, non-empty. |
-| `U_AGENTS_MACHINE_ID` | Stable machine/host identity. | Required, non-empty. |
+| `U_AGENTS_DATABASE_URL` | PostgreSQL connection URL. | Required, non-empty, `postgresql://` or `postgres://`. |
+| `U_AGENTS_RUNNER_ID` | Stable runner process/service identity. | Required, non-empty, not a placeholder such as `runner`, `placeholder`, `changeme`, or `todo`. |
+| `U_AGENTS_MACHINE_ID` | Stable machine/host identity. | Required, non-empty, not a placeholder such as `machine`, `placeholder`, `changeme`, or `example`. |
 
 ## Table: agent_runs
 
@@ -121,3 +132,7 @@ Automated PR review comment fixes are allowed at most once.
 
 Review comment classification must distinguish must-fix items from optional,
 rejected, stale, or already-addressed comments before applying these rules.
+
+The PR watcher never merges a PR. `ready_to_merge` is a notification state for
+the user/operator after GitHub PR existence, head branch, CI, and must-fix
+comment state have been verified.

--- a/u_agents/launcher.py
+++ b/u_agents/launcher.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-"""v0.1 Launcher: short-lived starter/resumer for tmux PM agents.
+"""v0.2 Launcher: DB-backed starter/resumer for tmux PM agents.
 
-Picks one status:ready issue from an enabled target repository, claims it
-by swapping labels and posting a claim comment, ensures a deterministic
-tmux window exists, and sends the PM prompt into that window.
+Picks one status:ready issue from an enabled target repository, acquires an
+agent_runs claim lease, re-verifies GitHub state, swaps labels, ensures a
+deterministic tmux window exists, and sends the PM prompt into that window.
 
-Read-only on GitHub by default; --dry-run additionally suppresses tmux
-writes and claim mutations. GitHub authentication is required for issue
-listing in both modes.
+Live runs mutate GitHub labels and comments after the DB claim succeeds.
+--dry-run suppresses DB, GitHub, and tmux writes while printing intended
+actions. GitHub authentication is required for issue listing in both modes.
 """
 from __future__ import annotations
 
@@ -23,6 +23,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, List, Optional
 
+from u_agents.agent_runs import (
+    AgentRun,
+    AgentRunsClient,
+    ClaimPayload,
+    build_claim_payload,
+)
 from u_agents.contract import (
     LABEL_IN_PROGRESS,
     LABEL_READY,
@@ -36,6 +42,7 @@ from u_agents.contract import (
     tmux_window_name,
     worktree_path,
 )
+from u_agents.control_plane import RunnerIdentity, load_runner_identity
 
 PACKAGE_DIR = Path(__file__).resolve().parent
 
@@ -64,6 +71,67 @@ class Issue:
     title: str
     url: str
     labels: List[str]
+
+
+class DryRunAgentRunsClient:
+    def __init__(self, identity: RunnerIdentity):
+        self.identity = identity
+
+    def acquire_claim(self, payload: ClaimPayload) -> AgentRun:
+        print(
+            "DRY: would acquire agent_runs claim lease for "
+            f"{payload.repository_full_name}#{payload.github_issue_number} "
+            f"(phase={payload.phase}, locked_by={payload.locked_by}, "
+            f"lease_until={payload.lease_until.isoformat()}, "
+            f"worktree_basename={payload.worktree_basename}, "
+            f"tmux_window={payload.tmux_window})",
+            file=sys.stderr,
+        )
+        return AgentRun(
+            repository_full_name=payload.repository_full_name,
+            github_issue_number=payload.github_issue_number,
+            parent_branch=payload.parent_branch,
+            branch_name=payload.branch_name,
+            phase=payload.phase,
+            runner_id=payload.runner_id,
+            machine_id=payload.machine_id,
+            locked_by=payload.locked_by,
+            lease_until=payload.lease_until,
+            worktree_basename=payload.worktree_basename,
+            tmux_window=payload.tmux_window,
+        )
+
+    def mark_pm_started(self, run: AgentRun) -> AgentRun:
+        print(
+            "DRY: would update agent_runs phase to 'pm_started' for "
+            f"{run.repository_full_name}#{run.github_issue_number} "
+            f"with pm_pane={pm_pane_target(run.tmux_window)}",
+            file=sys.stderr,
+        )
+        return AgentRun(
+            repository_full_name=run.repository_full_name,
+            github_issue_number=run.github_issue_number,
+            parent_branch=run.parent_branch,
+            branch_name=run.branch_name,
+            phase="pm_started",
+            runner_id=run.runner_id,
+            machine_id=run.machine_id,
+            locked_by=run.locked_by,
+            lease_until=run.lease_until,
+            worktree_basename=run.worktree_basename,
+            tmux_window=run.tmux_window,
+            pm_pane=pm_pane_target(run.tmux_window),
+        )
+
+    def cancel_run(self, repo_full: str, issue_number: int, *, metadata=None):
+        print(
+            f"DRY: would cancel agent_runs row for {repo_full}#{issue_number} "
+            f"metadata={metadata or {}}",
+            file=sys.stderr,
+        )
+
+    def close(self) -> None:
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -184,6 +252,24 @@ def fetch_issue(repo: RepoConfig, number: int) -> Optional[Issue]:
         url=str(data.get("url", "")),
         labels=labels,
     )
+
+
+def issue_is_ready(issue: Issue) -> bool:
+    return LABEL_READY in issue.labels and LABEL_IN_PROGRESS not in issue.labels
+
+
+def reverify_issue_ready(repo: RepoConfig, number: int) -> Optional[Issue]:
+    issue = fetch_issue(repo, number)
+    if issue is None:
+        return None
+    if not issue_is_ready(issue):
+        print(
+            f"SKIP: {repo.full_name}#{number} is no longer {LABEL_READY}; "
+            "aborting after DB claim and before label mutation",
+            file=sys.stderr,
+        )
+        return None
+    return issue
 
 
 def rollback_claim(issue: Issue, dry_run: bool) -> bool:
@@ -467,6 +553,21 @@ def _tmux_in(cmd: List[str], data: str) -> None:
 # Orchestration
 # ---------------------------------------------------------------------------
 
+def create_agent_runs_client(dry_run: bool):
+    if dry_run:
+        return DryRunAgentRunsClient(load_runner_identity())
+    return AgentRunsClient.from_env()
+
+
+def _agent_runs_client(args):
+    client = getattr(args, "agent_runs_client", None)
+    if client is not None:
+        return client
+    client = create_agent_runs_client(args.dry_run)
+    setattr(args, "agent_runs_client", client)
+    return client
+
+
 def pick_issue(
     repos: List[RepoConfig],
     target_repo: Optional[str],
@@ -581,14 +682,45 @@ def _resolve_repo(repos: List[RepoConfig], name: str) -> Optional[RepoConfig]:
 def dispatch_claim(issue: Issue, args) -> int:
     """Full claim flow with partial-claim rollback.
 
-    Order: label swap -> ensure window -> claim comment -> send prompt.
-    If anything after the swap raises, attempt to revert the label so the
-    issue re-enters the queue. The resume sweep recovers it next run if
-    the rollback itself fails.
+    Order: DB claim/lease -> GitHub re-check -> label swap -> tmux PM prompt
+    -> phase=pm_started. If anything after the swap raises, attempt to revert
+    the label so the issue re-enters the queue. The resume sweep recovers it
+    next run if the rollback itself fails.
     """
     repo = issue.repo
     window = tmux_window_name(repo, issue.number)
     window_preexisted = False
+    db = _agent_runs_client(args)
+
+    payload = build_claim_payload(
+        repo,
+        issue.number,
+        branch_name(issue.number),
+        db.identity,
+    )
+    print(
+        f"Claiming {repo.full_name}#{issue.number} \"{issue.title}\"",
+        file=sys.stderr,
+    )
+    try:
+        run = db.acquire_claim(payload)
+    except Exception as e:
+        print(
+            f"ERROR: DB claim failed for {repo.full_name}#{issue.number}: "
+            f"{type(e).__name__}: {e}\n"
+            f"       Aborting dispatch before GitHub label mutation or tmux work.",
+            file=sys.stderr,
+        )
+        return 2
+
+    current = issue if args.dry_run else reverify_issue_ready(repo, issue.number)
+    if current is None:
+        db.cancel_run(
+            repo.full_name,
+            issue.number,
+            metadata={"cancel_reason": "github_reverification_failed"},
+        )
+        return 0
 
     if not args.dry_run and window_exists(window):
         window_preexisted = True
@@ -599,14 +731,15 @@ def dispatch_claim(issue: Issue, args) -> int:
             f"      If the existing PM is dead: tmux kill-window -t {TMUX_SESSION}:{window}",
             file=sys.stderr,
         )
+        db.cancel_run(
+            repo.full_name,
+            issue.number,
+            metadata={"cancel_reason": "tmux_window_already_exists"},
+        )
         return 0
 
-    print(
-        f"Claiming {repo.full_name}#{issue.number} \"{issue.title}\"",
-        file=sys.stderr,
-    )
     try:
-        swapped = claim_issue(issue, args.dry_run)
+        swapped = claim_issue(current, args.dry_run)
     except RuntimeError as e:
         print(
             f"ERROR: claim failed for {repo.full_name}#{issue.number}: {e}\n"
@@ -622,10 +755,11 @@ def dispatch_claim(issue: Issue, args) -> int:
         )
         return 2
     try:
-        ensure_window(repo, issue, args.dry_run)
-        post_claim_comment(issue, window, args.dry_run)
-        prompt = render_pm_prompt(args.prompt_template, issue, window)
+        ensure_window(repo, current, args.dry_run)
+        post_claim_comment(current, window, args.dry_run)
+        prompt = render_pm_prompt(args.prompt_template, current, window)
         send_prompt(window, prompt, args.dry_run)
+        db.mark_pm_started(run)
     except Exception as e:
         if swapped:
             print(
@@ -634,7 +768,7 @@ def dispatch_claim(issue: Issue, args) -> int:
                 f"       Attempting label rollback for {repo.full_name}#{issue.number}",
                 file=sys.stderr,
             )
-            rollback_claim(issue, args.dry_run)
+            rollback_claim(current, args.dry_run)
             if not args.dry_run and not window_preexisted and window_exists(window):
                 print(
                     f"       Cleaning up newly created tmux window "
@@ -642,6 +776,11 @@ def dispatch_claim(issue: Issue, args) -> int:
                     file=sys.stderr,
                 )
                 kill_window(window, args.dry_run)
+            db.cancel_run(
+                repo.full_name,
+                issue.number,
+                metadata={"cancel_reason": "dispatch_failed_after_label_swap"},
+            )
         else:
             print(
                 f"ERROR: dispatch failed: {type(e).__name__}: {e}",
@@ -694,7 +833,9 @@ def dispatch_resume(issue: Issue, args) -> int:
 
 
 def main(argv=None) -> int:
-    p = argparse.ArgumentParser(description="v0.1 Launcher for tmux PM agents")
+    p = argparse.ArgumentParser(
+        description="v0.2 DB-backed Launcher for tmux PM agents"
+    )
     p.add_argument("--config", type=Path, help="repositories config path (yaml or json)")
     p.add_argument("--dry-run", action="store_true",
                    help="do not mutate GitHub or tmux; print intended actions")

--- a/u_agents/mise.toml
+++ b/u_agents/mise.toml
@@ -21,6 +21,10 @@ dir = ".."
 run = "python3 -m u_agents.watchdog --once"
 dir = ".."
 
+[tasks.pr-watcher]
+run = "python3 -m u_agents.pr_watcher --once"
+dir = ".."
+
 [tasks.test]
 run = "python3 -m unittest discover tests"
 dir = ".."

--- a/u_agents/pr_watcher.py
+++ b/u_agents/pr_watcher.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""DB-backed PR watcher for u_agents."""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Callable
+
+from u_agents.agent_runs import AgentRun, AgentRunsClient
+from u_agents.control_plane import decide_pr_watch_phase
+
+
+@dataclass(frozen=True)
+class PrReality:
+    exists: bool
+    pr_number: int
+    head_branch: str
+    merged: bool
+    ci_green: bool
+    must_fix_review_comments: bool
+    closed: bool = False
+    must_fix_comment_keys: tuple[str, ...] = ()
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+
+def _status_checks_green(status_rollup) -> bool:
+    if not isinstance(status_rollup, list) or not status_rollup:
+        return False
+    conclusions = []
+    for check in status_rollup:
+        if not isinstance(check, dict):
+            return False
+        conclusion = check.get("conclusion")
+        status = check.get("status")
+        if conclusion is None and status != "COMPLETED":
+            return False
+        conclusions.append(conclusion)
+    return all(c in ("SUCCESS", "SKIPPED", "NEUTRAL") for c in conclusions)
+
+
+_MUST_FIX_MARKERS = (
+    "must_fix",
+    "must-fix",
+    "must fix",
+    "changes requested",
+    "blocking",
+    "blocker",
+)
+_NON_MUST_FIX_MARKERS = (
+    "optional",
+    "non-blocking",
+    "nonblocking",
+    "nit:",
+    "already addressed",
+    "addressed",
+    "resolved",
+    "stale",
+    "rejected",
+)
+
+
+def _comment_body(item) -> str:
+    if not isinstance(item, dict):
+        return ""
+    return str(item.get("body") or "")
+
+
+def _comment_key(prefix: str, item: dict, fallback_index: int) -> str:
+    value = item.get("id") or item.get("databaseId") or item.get("url")
+    if value:
+        return f"{prefix}:{value}"
+    return f"{prefix}:index-{fallback_index}"
+
+
+def _body_has_must_fix_signal(body: str) -> bool:
+    normalized = body.lower().replace("_", "-")
+    if not any(marker in normalized for marker in _MUST_FIX_MARKERS):
+        return False
+    return not any(marker in normalized for marker in _NON_MUST_FIX_MARKERS)
+
+
+def extract_must_fix_review_comment_keys(pr_data: dict) -> tuple[str, ...]:
+    """Classify PR comments/reviews with explicit must-fix signals.
+
+    This is intentionally conservative and testable. Runtime callers still
+    pass the resulting truth through `PrReality`, and tests can inject richer
+    classification without depending on GitHub's JSON shape.
+    """
+    keys: list[str] = []
+    for prefix, field in (
+        ("comment", "comments"),
+        ("review", "reviews"),
+        ("latest_review", "latestReviews"),
+    ):
+        values = pr_data.get(field) or []
+        if not isinstance(values, list):
+            continue
+        for index, item in enumerate(values):
+            if not isinstance(item, dict):
+                continue
+            state = str(item.get("state") or "").upper()
+            body = _comment_body(item)
+            if state == "CHANGES_REQUESTED" or _body_has_must_fix_signal(body):
+                keys.append(_comment_key(prefix, item, index))
+    return tuple(keys)
+
+
+def fetch_pr_reality(repository_full_name: str, pr_number: int) -> PrReality:
+    res = _run([
+        "gh", "pr", "view", str(pr_number),
+        "--repo", repository_full_name,
+        "--json",
+        (
+            "number,headRefName,state,merged,statusCheckRollup,reviewDecision,"
+            "comments,reviews,latestReviews"
+        ),
+    ])
+    if res.returncode != 0:
+        return PrReality(
+            exists=False,
+            pr_number=pr_number,
+            head_branch="",
+            merged=False,
+            ci_green=False,
+            must_fix_review_comments=False,
+        )
+    try:
+        data = json.loads(res.stdout)
+    except json.JSONDecodeError:
+        return PrReality(
+            exists=False,
+            pr_number=pr_number,
+            head_branch="",
+            merged=False,
+            ci_green=False,
+            must_fix_review_comments=False,
+        )
+    state = data.get("state")
+    must_fix_comment_keys = extract_must_fix_review_comment_keys(data)
+    if not must_fix_comment_keys and data.get("reviewDecision") == "CHANGES_REQUESTED":
+        must_fix_comment_keys = ("reviewDecision:CHANGES_REQUESTED",)
+    return PrReality(
+        exists=True,
+        pr_number=int(data["number"]),
+        head_branch=str(data.get("headRefName") or ""),
+        merged=bool(data.get("merged")),
+        closed=state == "CLOSED",
+        ci_green=_status_checks_green(data.get("statusCheckRollup")),
+        must_fix_review_comments=bool(must_fix_comment_keys),
+        must_fix_comment_keys=must_fix_comment_keys,
+    )
+
+
+def reconcile_pr_run(
+    run: AgentRun,
+    reality: PrReality,
+    db_client,
+    *,
+    assign_fix: Callable[[AgentRun, PrReality], None] | None = None,
+) -> AgentRun:
+    if run.pr_number is None:
+        return db_client.mark_blocked(
+            run.repository_full_name,
+            run.github_issue_number,
+            "PR watcher cannot verify a run without pr_number",
+            metadata={"pr_watcher": {"verified": False}},
+        )
+    if not reality.exists:
+        return db_client.mark_blocked(
+            run.repository_full_name,
+            run.github_issue_number,
+            f"PR #{run.pr_number} does not exist on GitHub",
+            metadata={"pr_watcher": {"verified": False}},
+        )
+    if reality.pr_number != run.pr_number:
+        return db_client.mark_blocked(
+            run.repository_full_name,
+            run.github_issue_number,
+            f"GitHub returned PR #{reality.pr_number}; expected #{run.pr_number}",
+            metadata={"pr_watcher": {"verified": False}},
+        )
+    if reality.head_branch != run.branch_name:
+        return db_client.mark_blocked(
+            run.repository_full_name,
+            run.github_issue_number,
+            f"PR #{run.pr_number} head branch {reality.head_branch!r} "
+            f"does not match {run.branch_name!r}",
+            metadata={"pr_watcher": {"verified": False}},
+        )
+    if reality.closed and not reality.merged:
+        return db_client.mark_blocked(
+            run.repository_full_name,
+            run.github_issue_number,
+            f"PR #{run.pr_number} is closed without being merged",
+            metadata={"pr_watcher": {"verified": True, "closed": True}},
+        )
+
+    decision = decide_pr_watch_phase(
+        pr_merged=reality.merged,
+        ci_green=reality.ci_green,
+        must_fix_review_comments=reality.must_fix_review_comments,
+        pr_review_fix_rounds=run.pr_review_fix_rounds,
+    )
+    metadata = {
+        "pr_watcher": {
+            "verified": True,
+            "pr_number": reality.pr_number,
+            "head_branch": reality.head_branch,
+            "ci_green": reality.ci_green,
+            "must_fix_review_comments": reality.must_fix_review_comments,
+            "must_fix_review_comment_count": len(reality.must_fix_comment_keys),
+            "must_fix_comment_keys": list(reality.must_fix_comment_keys[:20]),
+            "merged": reality.merged,
+            "closed": reality.closed,
+        },
+    }
+    if decision.phase == "done":
+        return db_client.mark_done(
+            run.repository_full_name,
+            run.github_issue_number,
+            metadata=metadata,
+        )
+    if decision.phase == "blocked":
+        return db_client.mark_blocked(
+            run.repository_full_name,
+            run.github_issue_number,
+            decision.block_reason,
+            metadata=metadata,
+        )
+    updated = db_client.update_pr_fields(
+        run.repository_full_name,
+        run.github_issue_number,
+        pr_number=reality.pr_number,
+        phase=decision.phase,
+        increment_fix_rounds=decision.increment_fix_rounds,
+        metadata=metadata,
+    )
+    if decision.increment_fix_rounds and assign_fix is not None:
+        assign_fix(updated, reality)
+    return updated
+
+
+def check_once(
+    db_client,
+    *,
+    fetch_reality: Callable[[str, int], PrReality] = fetch_pr_reality,
+    assign_fix: Callable[[AgentRun, PrReality], None] | None = None,
+) -> list[AgentRun]:
+    updated: list[AgentRun] = []
+    for run in db_client.list_pr_watch_runs():
+        if run.pr_number is None:
+            updated.append(reconcile_pr_run(
+                run,
+                PrReality(False, 0, "", False, False, False),
+                db_client,
+                assign_fix=assign_fix,
+            ))
+            continue
+        reality = fetch_reality(run.repository_full_name, run.pr_number)
+        updated.append(reconcile_pr_run(
+            run,
+            reality,
+            db_client,
+            assign_fix=assign_fix,
+        ))
+    return updated
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description="v0.2 PR watcher for u_agents")
+    p.add_argument("--once", action="store_true", help="run one pass and exit")
+    args = p.parse_args(argv)
+    db_client = AgentRunsClient.from_env()
+    try:
+        updated = check_once(db_client)
+        for run in updated:
+            print(
+                f"{run.repository_full_name}#{run.github_issue_number}: "
+                f"phase={run.phase} pr={run.pr_number}",
+                file=sys.stderr,
+            )
+        if args.once:
+            return 0
+        return 0
+    finally:
+        db_client.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/u_agents/pr_watcher.py
+++ b/u_agents/pr_watcher.py
@@ -30,18 +30,32 @@ def _run(cmd: list[str]) -> subprocess.CompletedProcess:
 
 
 def _status_checks_green(status_rollup) -> bool:
+    """Whether every status-rollup entry is green.
+
+    GitHub's ``statusCheckRollup`` mixes two GraphQL shapes:
+    - ``CheckRun`` entries expose ``status`` (e.g. ``COMPLETED``) and
+      ``conclusion`` (``SUCCESS``/``SKIPPED``/``NEUTRAL``/``FAILURE``/...).
+    - ``StatusContext`` entries (classic commit statuses) expose ``state``
+      (``SUCCESS``/``PENDING``/``FAILURE``/``ERROR``/``EXPECTED``).
+    A successful classic status counts as green; pending/failing/error classic
+    statuses do not.
+    """
     if not isinstance(status_rollup, list) or not status_rollup:
         return False
-    conclusions = []
     for check in status_rollup:
         if not isinstance(check, dict):
             return False
-        conclusion = check.get("conclusion")
-        status = check.get("status")
-        if conclusion is None and status != "COMPLETED":
-            return False
-        conclusions.append(conclusion)
-    return all(c in ("SUCCESS", "SKIPPED", "NEUTRAL") for c in conclusions)
+        if "state" in check:
+            if check.get("state") != "SUCCESS":
+                return False
+        else:
+            status = check.get("status")
+            conclusion = check.get("conclusion")
+            if status != "COMPLETED" or conclusion not in (
+                "SUCCESS", "SKIPPED", "NEUTRAL"
+            ):
+                return False
+    return True
 
 
 _MUST_FIX_MARKERS = (
@@ -88,6 +102,11 @@ def _body_has_must_fix_signal(body: str) -> bool:
 def extract_must_fix_review_comment_keys(pr_data: dict) -> tuple[str, ...]:
     """Classify PR comments/reviews with explicit must-fix signals.
 
+    Only ``comments`` and ``latestReviews`` (the latest review per reviewer)
+    are considered. The historical ``reviews`` list is intentionally excluded
+    so a superseded ``CHANGES_REQUESTED`` review that was later replaced by an
+    ``APPROVED`` review does not keep a PR blocked forever.
+
     This is intentionally conservative and testable. Runtime callers still
     pass the resulting truth through `PrReality`, and tests can inject richer
     classification without depending on GitHub's JSON shape.
@@ -95,7 +114,6 @@ def extract_must_fix_review_comment_keys(pr_data: dict) -> tuple[str, ...]:
     keys: list[str] = []
     for prefix, field in (
         ("comment", "comments"),
-        ("review", "reviews"),
         ("latest_review", "latestReviews"),
     ):
         values = pr_data.get(field) or []
@@ -111,6 +129,23 @@ def extract_must_fix_review_comment_keys(pr_data: dict) -> tuple[str, ...]:
     return tuple(keys)
 
 
+# "could not resolve to" matches GitHub GraphQL missing-resource errors
+# (e.g. "Could not resolve to a PullRequest ..."). It deliberately excludes
+# transient DNS/network failures like "Could not resolve host: api.github.com".
+_PR_ABSENCE_MARKERS = ("not found", "could not resolve to", "404")
+
+
+def _missing_pr_reality(pr_number: int) -> PrReality:
+    return PrReality(
+        exists=False,
+        pr_number=pr_number,
+        head_branch="",
+        merged=False,
+        ci_green=False,
+        must_fix_review_comments=False,
+    )
+
+
 def fetch_pr_reality(repository_full_name: str, pr_number: int) -> PrReality:
     res = _run([
         "gh", "pr", "view", str(pr_number),
@@ -118,29 +153,28 @@ def fetch_pr_reality(repository_full_name: str, pr_number: int) -> PrReality:
         "--json",
         (
             "number,headRefName,state,merged,statusCheckRollup,reviewDecision,"
-            "comments,reviews,latestReviews"
+            "comments,latestReviews"
         ),
     ])
     if res.returncode != 0:
-        return PrReality(
-            exists=False,
-            pr_number=pr_number,
-            head_branch="",
-            merged=False,
-            ci_green=False,
-            must_fix_review_comments=False,
+        stderr = (res.stderr or "").lower()
+        if any(marker in stderr for marker in _PR_ABSENCE_MARKERS):
+            return _missing_pr_reality(pr_number)
+        # Transient network/rate-limit/outage: do not let it masquerade as a
+        # definitively missing PR (which would terminally block the run).
+        raise RuntimeError(
+            f"gh pr view failed for {repository_full_name}#{pr_number} "
+            f"(exit {res.returncode}); treating as transient: "
+            f"{(res.stderr or '').strip()}"
         )
     try:
         data = json.loads(res.stdout)
-    except json.JSONDecodeError:
-        return PrReality(
-            exists=False,
-            pr_number=pr_number,
-            head_branch="",
-            merged=False,
-            ci_green=False,
-            must_fix_review_comments=False,
-        )
+    except json.JSONDecodeError as e:
+        # Malformed CLI output is ambiguous, not proof the PR is gone.
+        raise RuntimeError(
+            f"gh pr view returned unparseable JSON for "
+            f"{repository_full_name}#{pr_number}: {e}"
+        ) from e
     state = data.get("state")
     must_fix_comment_keys = extract_must_fix_review_comment_keys(data)
     if not must_fix_comment_keys and data.get("reviewDecision") == "CHANGES_REQUESTED":
@@ -262,7 +296,17 @@ def check_once(
                 assign_fix=assign_fix,
             ))
             continue
-        reality = fetch_reality(run.repository_full_name, run.pr_number)
+        try:
+            reality = fetch_reality(run.repository_full_name, run.pr_number)
+        except RuntimeError as e:
+            # Transient/ambiguous fetch failure: skip this run so it is retried
+            # on the next pass instead of being terminally blocked.
+            print(
+                f"WARN: deferring PR watch for {run.repository_full_name}#"
+                f"{run.github_issue_number}: {e}",
+                file=sys.stderr,
+            )
+            continue
         updated.append(reconcile_pr_run(
             run,
             reality,

--- a/u_agents/watchdog.py
+++ b/u_agents/watchdog.py
@@ -265,8 +265,20 @@ def post_stall_comment(
         )
 
 
+# "could not resolve to" matches GitHub GraphQL missing-resource errors
+# (e.g. "Could not resolve to an Issue ..."). It deliberately excludes
+# transient DNS/network failures like "Could not resolve host: api.github.com".
+_ISSUE_ABSENCE_MARKERS = ("not found", "could not resolve to", "404")
+
+
 def github_issue_allows_watchdog_action(run: AgentRun) -> bool:
-    """Verify GitHub issue reality before pinging or commenting on a DB row."""
+    """Verify GitHub issue reality before pinging or commenting on a DB row.
+
+    Returns ``False`` for definitive non-actionable reality (issue not OPEN,
+    not found, or missing the required label). Raises ``RuntimeError`` for
+    transient/ambiguous CLI/API failures so the loop logs and retries instead
+    of recording a false ``github_issue_verification_failed`` observation.
+    """
     res = subprocess.run(
         [
             "gh", "issue", "view", str(run.github_issue_number),
@@ -276,21 +288,27 @@ def github_issue_allows_watchdog_action(run: AgentRun) -> bool:
         capture_output=True, text=True, check=False,
     )
     if res.returncode != 0:
-        print(
-            f"WARN: cannot verify issue for {run.repository_full_name}#"
-            f"{run.github_issue_number}: {(res.stderr or '').strip()}",
-            file=sys.stderr,
+        stderr = (res.stderr or "").strip()
+        if any(marker in stderr.lower() for marker in _ISSUE_ABSENCE_MARKERS):
+            print(
+                f"WARN: cannot verify issue for {run.repository_full_name}#"
+                f"{run.github_issue_number}: {stderr}",
+                file=sys.stderr,
+            )
+            return False
+        raise RuntimeError(
+            f"cannot verify issue {run.repository_full_name}#"
+            f"{run.github_issue_number} (exit {res.returncode}); "
+            f"treating as transient: {stderr}"
         )
-        return False
     try:
         data = json.loads(res.stdout)
     except json.JSONDecodeError as e:
-        print(
-            f"WARN: malformed issue verification JSON for "
-            f"{run.repository_full_name}#{run.github_issue_number}: {e}",
-            file=sys.stderr,
-        )
-        return False
+        # Malformed CLI output is ambiguous, not proof the issue is gone.
+        raise RuntimeError(
+            f"malformed issue verification JSON for "
+            f"{run.repository_full_name}#{run.github_issue_number}: {e}"
+        ) from e
     if data.get("state") != "OPEN":
         return False
     labels = {str(label.get("name", "")) for label in data.get("labels", [])}
@@ -435,7 +453,18 @@ def check_once(
     else:
         candidate_runs = []
         for run in _runs_for_reconciliation(db_client):
-            if verify_run(run):
+            try:
+                allowed = verify_run(run)
+            except RuntimeError as e:
+                # Transient/ambiguous verification failure: skip this run so the
+                # outer loop retries next tick instead of polluting DB metadata.
+                print(
+                    f"WARN: deferring watchdog action for "
+                    f"{run.repository_full_name}#{run.github_issue_number}: {e}",
+                    file=sys.stderr,
+                )
+                continue
+            if allowed:
                 candidate_runs.append(run)
                 continue
             db_client.record_observation(

--- a/u_agents/watchdog.py
+++ b/u_agents/watchdog.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""v0.1 lightweight watchdog for tmux PM agents.
+"""v0.2 DB-backed watchdog for tmux PM agents.
 
-Periodically captures each PM pane, compares with stored hashes, pings the
-pane if it is unchanged across several consecutive checks, and posts a
+Discovers active/stale PM runs through agent_runs, verifies external GitHub
+and tmux reality, captures each PM pane, compares with stored hashes, pings
+the pane if it is unchanged across several consecutive checks, and posts a
 single GitHub issue comment if it is still unchanged after the ping.
 
-The watchdog does not own workflow state. It only detects stalls.
+The watchdog uses local JSON only for pane-stall counters.
 """
 from __future__ import annotations
 
@@ -19,9 +20,12 @@ import tempfile
 import time
 from dataclasses import asdict, dataclass, fields
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
+from u_agents.agent_runs import ACTIVE_PHASES, AgentRun, AgentRunsClient, TERMINAL_PHASES
 from u_agents.contract import (
+    LABEL_IN_PROGRESS,
+    LABEL_READY,
     RepoConfig,
     TMUX_SESSION,
     load_config,
@@ -261,6 +265,40 @@ def post_stall_comment(
         )
 
 
+def github_issue_allows_watchdog_action(run: AgentRun) -> bool:
+    """Verify GitHub issue reality before pinging or commenting on a DB row."""
+    res = subprocess.run(
+        [
+            "gh", "issue", "view", str(run.github_issue_number),
+            "--repo", run.repository_full_name,
+            "--json", "state,labels",
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    if res.returncode != 0:
+        print(
+            f"WARN: cannot verify issue for {run.repository_full_name}#"
+            f"{run.github_issue_number}: {(res.stderr or '').strip()}",
+            file=sys.stderr,
+        )
+        return False
+    try:
+        data = json.loads(res.stdout)
+    except json.JSONDecodeError as e:
+        print(
+            f"WARN: malformed issue verification JSON for "
+            f"{run.repository_full_name}#{run.github_issue_number}: {e}",
+            file=sys.stderr,
+        )
+        return False
+    if data.get("state") != "OPEN":
+        return False
+    labels = {str(label.get("name", "")) for label in data.get("labels", [])}
+    if run.phase == "claimed":
+        return LABEL_READY in labels or LABEL_IN_PROGRESS in labels
+    return LABEL_IN_PROGRESS in labels
+
+
 # ---------------------------------------------------------------------------
 # Core check
 # ---------------------------------------------------------------------------
@@ -280,6 +318,100 @@ def resolve_repo(window: str, repos: List[RepoConfig]) -> Optional[Tuple[RepoCon
     return None
 
 
+def _db_windows_for_check(
+    runs: Iterable[AgentRun],
+    repos: List[RepoConfig],
+    live_windows: set[str],
+    db_client,
+) -> Tuple[List[str], Dict[str, Tuple[str, int]]]:
+    configured_repos = {repo.full_name for repo in repos}
+    windows: List[str] = []
+    window_lookup: Dict[str, Tuple[str, int]] = {}
+    for run in runs:
+        if run.phase in TERMINAL_PHASES:
+            continue
+        if run.phase not in ACTIVE_PHASES:
+            continue
+        if run.repository_full_name not in configured_repos:
+            db_client.record_observation(
+                run.repository_full_name,
+                run.github_issue_number,
+                {
+                    "watchdog": "repository_not_configured",
+                    "repository_full_name": run.repository_full_name,
+                },
+            )
+            print(
+                f"WARN: DB row {run.repository_full_name}#"
+                f"{run.github_issue_number} is not in watchdog config; "
+                "skipping pane action",
+                file=sys.stderr,
+            )
+            continue
+        if run.tmux_window not in live_windows:
+            db_client.record_observation(
+                run.repository_full_name,
+                run.github_issue_number,
+                {
+                    "watchdog": "tmux_window_missing",
+                    "tmux_window": run.tmux_window,
+                    "pm_pane": run.pm_pane,
+                },
+            )
+            print(
+                f"WARN: DB row {run.repository_full_name}#"
+                f"{run.github_issue_number} points at missing tmux window "
+                f"{run.tmux_window}; skipping pane action",
+                file=sys.stderr,
+            )
+            continue
+        if run.pm_pane is not None and run.pm_pane != pm_pane_target(run.tmux_window):
+            db_client.record_observation(
+                run.repository_full_name,
+                run.github_issue_number,
+                {
+                    "watchdog": "pm_pane_mismatch",
+                    "tmux_window": run.tmux_window,
+                    "pm_pane": run.pm_pane,
+                    "expected_pm_pane": pm_pane_target(run.tmux_window),
+                },
+            )
+            print(
+                f"WARN: DB row {run.repository_full_name}#"
+                f"{run.github_issue_number} has pm_pane {run.pm_pane!r}; "
+                f"expected {pm_pane_target(run.tmux_window)!r}; skipping pane action",
+                file=sys.stderr,
+            )
+            continue
+        windows.append(run.tmux_window)
+        window_lookup[run.tmux_window] = (
+            run.repository_full_name,
+            run.github_issue_number,
+        )
+    return windows, window_lookup
+
+
+def _runs_for_reconciliation(db_client) -> List[AgentRun]:
+    runs_by_key: Dict[Tuple[str, int], AgentRun] = {}
+    for run in db_client.list_active_runs():
+        runs_by_key[(run.repository_full_name, run.github_issue_number)] = run
+    for run in db_client.list_stale_runs():
+        runs_by_key[(run.repository_full_name, run.github_issue_number)] = run
+        db_client.record_observation(
+            run.repository_full_name,
+            run.github_issue_number,
+            {
+                "watchdog": "stale_lease",
+                "lease_until": (
+                    run.lease_until.isoformat()
+                    if hasattr(run.lease_until, "isoformat")
+                    else str(run.lease_until)
+                ),
+            },
+        )
+    return list(runs_by_key.values())
+
+
 def check_once(
     repos: List[RepoConfig],
     state_file: Path,
@@ -291,10 +423,35 @@ def check_once(
     ping: Callable[[str, bool], bool] = send_ping,
     comment: Callable[[str, int, str, str, int, bool], None] = post_stall_comment,
     now: Callable[[], float] = time.time,
+    db_client=None,
+    verify_run: Callable[[AgentRun], bool] = github_issue_allows_watchdog_action,
 ) -> Dict[str, WindowState]:
     """Single check pass. Returns the updated in-memory state."""
     state = load_state(state_file)
-    windows = list_windows()
+    live_windows = list_windows()
+    db_window_lookup: Dict[str, Tuple[str, int]] = {}
+    if db_client is None:
+        windows = live_windows
+    else:
+        candidate_runs = []
+        for run in _runs_for_reconciliation(db_client):
+            if verify_run(run):
+                candidate_runs.append(run)
+                continue
+            db_client.record_observation(
+                run.repository_full_name,
+                run.github_issue_number,
+                {
+                    "watchdog": "github_issue_verification_failed",
+                    "phase": run.phase,
+                },
+            )
+        windows, db_window_lookup = _db_windows_for_check(
+            candidate_runs,
+            repos,
+            set(live_windows),
+            db_client,
+        )
     seen: set[str] = set()
 
     for w in windows:
@@ -325,7 +482,11 @@ def check_once(
                 and not st.stall_comment_posted
             ):
                 resolved = resolve_repo(w, repos)
-                if resolved is None:
+                if w in db_window_lookup:
+                    repo_full, num = db_window_lookup[w]
+                    comment(repo_full, num, w, text, st.unchanged_checks, dry_run)
+                    st.stall_comment_posted = True
+                elif resolved is None:
                     print(
                         f"WARN: cannot resolve repo for window {w}; skipping stall comment",
                         file=sys.stderr,
@@ -355,7 +516,7 @@ def _resolve_config(explicit: Optional[Path]) -> Path:
 
 
 def main(argv=None) -> int:
-    p = argparse.ArgumentParser(description="v0.1 PM pane watchdog")
+    p = argparse.ArgumentParser(description="v0.2 DB-backed PM pane watchdog")
     p.add_argument("--config", type=Path)
     p.add_argument("--state-dir", type=Path, default=DEFAULT_STATE_DIR)
     p.add_argument("--interval", type=int, default=60,
@@ -377,6 +538,7 @@ def main(argv=None) -> int:
     config_path = _resolve_config(args.config)
     repos = load_config(config_path)
     state_file = args.state_dir / DEFAULT_STATE_FILE
+    db_client = AgentRunsClient.from_env()
 
     def comment_with_flag(repo_full, num, w, text, unchanged, dry):
         post_stall_comment(
@@ -387,14 +549,13 @@ def main(argv=None) -> int:
     def run_once():
         check_once(
             repos, state_file, args.stall_checks, args.dry_run,
-            comment=comment_with_flag,
+            comment=comment_with_flag, db_client=db_client,
         )
 
-    if args.once:
-        run_once()
-        return 0
-
     try:
+        if args.once:
+            run_once()
+            return 0
         while True:
             try:
                 run_once()
@@ -403,6 +564,8 @@ def main(argv=None) -> int:
             time.sleep(args.interval)
     except KeyboardInterrupt:
         return 0
+    finally:
+        db_client.close()
 
 
 if __name__ == "__main__":

--- a/u_agents/watchdog.py
+++ b/u_agents/watchdog.py
@@ -447,7 +447,13 @@ def check_once(
     """Single check pass. Returns the updated in-memory state."""
     state = load_state(state_file)
     live_windows = list_windows()
+    live_window_set = set(live_windows)
     db_window_lookup: Dict[str, Tuple[str, int]] = {}
+    # Windows of runs deferred this pass by a transient verification failure.
+    # Their stall state must survive the cleanup sweep below even though no
+    # pane action runs for them, so a sustained outage cannot keep resetting
+    # unchanged_checks / pinged / stall_comment_posted.
+    deferred_windows: set[str] = set()
     if db_client is None:
         windows = live_windows
     else:
@@ -458,6 +464,11 @@ def check_once(
             except RuntimeError as e:
                 # Transient/ambiguous verification failure: skip this run so the
                 # outer loop retries next tick instead of polluting DB metadata.
+                # If its tmux window is still live, preserve that window's stall
+                # state through cleanup; a gone window is left out so genuinely
+                # stale state can still expire normally.
+                if run.tmux_window in live_window_set:
+                    deferred_windows.add(run.tmux_window)
                 print(
                     f"WARN: deferring watchdog action for "
                     f"{run.repository_full_name}#{run.github_issue_number}: {e}",
@@ -478,10 +489,13 @@ def check_once(
         windows, db_window_lookup = _db_windows_for_check(
             candidate_runs,
             repos,
-            set(live_windows),
+            live_window_set,
             db_client,
         )
-    seen: set[str] = set()
+    # Seed `seen` with deferred live windows so the cleanup sweep keeps their
+    # existing WindowState. They stay out of `windows`, so no capture / ping /
+    # comment / counter update happens for them this pass.
+    seen: set[str] = set(deferred_windows)
 
     for w in windows:
         seen.add(w)


### PR DESCRIPTION
## Summary

- Implements #11 by wiring the PostgreSQL agent_runs runtime layer into launcher, watchdog, and PR watcher flows.
- Covers #12 with typed DB operations, env/identity validation, payload validation, and lazy psycopg import.
- Covers #13 with DB claim before GitHub label swap, post-claim GitHub re-verification, and pm_started tmux coordinate updates.
- Covers #14 with DB-backed watchdog active/stale discovery plus external GitHub/tmux verification and local JSON limited to pane-stall counters.
- Covers #15 with PR watcher phases, verified PR/head/CI/review state, one automated must-fix round, ready_to_merge/done/blocked transitions, and no auto-merge.

## Tests

- python3 -m unittest discover tests
- python3 -m u_agents.launcher --help
- python3 -m u_agents.watchdog --help
- python3 -m u_agents.pr_watcher --help

## Notes

- Launcher dry-run was attempted with non-placeholder runner identity, but GitHub issue listing failed with a network connection error before any ready issue could be observed.
- Optional local Postgres smoke was not run because Docker API access is unavailable in this sandbox.

Closes #11
Refs #12
Refs #13
Refs #14
Refs #15