### PR TITLE
Fix u_agents automation workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ __pycache__/
 u_agents/config/repositories.yml
 u_agents/config/repositories.yaml
 u_agents/state/
+# Real runner env with secrets lives in $HOME; never commit it even if copied
+# into the repo by mistake (the .template is tracked).
+.u_agents_env.zsh

--- a/.u_agents_env.zsh.template
+++ b/.u_agents_env.zsh.template
@@ -1,0 +1,23 @@
+# u-agents runner environment.
+#
+# Copy to ~/.u_agents_env.zsh and fill in real values, then start (or restart)
+# the tmux "agents" session so the PM pane and any `python3 -m u_agents.*` it
+# runs (e.g. mark_pr_open) inherit these. The real file lives outside the
+# dotfiles repo and is never committed; keep secrets here, not in tracked files.
+#
+#   cp .u_agents_env.zsh.template ~/.u_agents_env.zsh
+#   chmod 600 ~/.u_agents_env.zsh
+#   $EDITOR ~/.u_agents_env.zsh
+#
+# .zshrc sources ~/.u_agents_env.zsh when present. launchd-managed launcher /
+# watchdog jobs read the same variables from their plist EnvironmentVariables.
+
+# PostgreSQL control-plane URL. The value below is the local compose.yml dev
+# default; change it for any other database.
+export U_AGENTS_DATABASE_URL="postgresql://u_agents:u_agents_dev_password@127.0.0.1:54329/u_agents"
+
+# Stable identities. These MUST be set to real values: the placeholders
+# "runner" / "machine" are rejected by identity validation so an unedited copy
+# fails loudly instead of claiming work under a bogus identity.
+export U_AGENTS_RUNNER_ID="runner"
+export U_AGENTS_MACHINE_ID="machine"

--- a/.zshrc
+++ b/.zshrc
@@ -334,6 +334,12 @@ export CPPFLAGS="-I/usr/local/opt/zlib/include"
 # ChatGPT
 source "$HOME/.openai_key.zsh"
 
+# u-agents runner env (U_AGENTS_DATABASE_URL / RUNNER_ID / MACHINE_ID).
+# Copy .u_agents_env.zsh.template to ~/.u_agents_env.zsh and fill it in so the
+# tmux PM pane and launcher/watchdog share the same runtime identity. Guarded
+# so shells without the local file are unaffected. See docs/u-agents.md.
+[[ -f "$HOME/.u_agents_env.zsh" ]] && source "$HOME/.u_agents_env.zsh"
+
 # Embulk
 export PATH="$HOME/.embulk/bin:$PATH"
 

--- a/docs/u-agents.md
+++ b/docs/u-agents.md
@@ -15,6 +15,7 @@ PostgreSQL `agent_runs` coordinates claimed work across runner processes.
 | PM prompt  | `u_agents/prompts/pm.md`        | The contract sent into the PM pane. PM owns the per-issue workflow.  |
 | Watchdog   | `u_agents/watchdog.py`          | Detects stalled PM panes. Pings, then comments once if still stuck.  |
 | PR Watcher | `u_agents/pr_watcher.py`        | Watches verified PR state and updates PR phases in `agent_runs`.     |
+| PR-open CLI | `u_agents/mark_pr_open.py`      | PM-run helper that durably sets `phase=pr_open` + `pr_number` after a PR is opened. |
 | DB schema   | `u_agents/db/001_agent_runs.sql` | v0.2 PostgreSQL schema for claimed runs.                         |
 | DB docs     | `u_agents/db/README.md`         | Column ownership, phase contract, and PR watcher rules.             |
 | Config     | `u_agents/config/repositories.yml` | Local allowlist of repositories the Launcher may operate on.     |
@@ -84,6 +85,22 @@ If the labels do not exist, the Launcher aborts before creating a tmux
 window. Add the labels and re-run to enable proper queue semantics.
 
 Optional but recommended sizing labels: `size:s`, `size:m`, `size:l`.
+
+## mise-managed target repos
+
+Some target repos (and their per-issue worktrees) carry a `mise.toml`,
+`.mise.toml`, or `.config/mise/config.toml`. An untrusted mise config makes
+`mise run` / `mise exec` and shell auto-activation fail until it is trusted, so
+the PM trusts it as part of workspace setup:
+
+```sh
+mise trust <worktree>     # plus `mise install` if the repo declares tools
+```
+
+This is conditional on a mise config actually being present — the PM does not
+assume every repo uses mise, and skips trust entirely for repos without one.
+`prompts/pm.md` step 1 (workspace) encodes this. Trust the main checkout once
+the same way if it carries a mise config.
 
 ## Naming contract
 
@@ -169,6 +186,49 @@ Blank values and placeholders such as `runner`, `machine`, `placeholder`,
 `changeme`, `todo`, or `example` are rejected. Launcher dry-runs require the
 runner and machine identity because the dry-run output includes the DB claim
 lease owner; live DB paths also require `U_AGENTS_DATABASE_URL` and `psycopg`.
+
+### Making the env reproducible
+
+These variables must be present in every process that touches the DB. There
+are two delivery points, and both must agree:
+
+1. **launchd jobs** (launcher + watchdog) read them from the plist
+   `EnvironmentVariables` block. See "Scheduling under launchd" below.
+2. **The tmux PM pane** runs the rendered `u_agents.mark_pr_open` command after
+   opening a PR (see "PR-open bookkeeping"), so it needs the same values.
+   Deliver them by sourcing a local env file from `.zshrc` (per the repo's
+   AGENTS rule that env additions go in `.zshrc`, not `bootstrap.sh`):
+
+   ```sh
+   cp .u_agents_env.zsh.template ~/.u_agents_env.zsh
+   chmod 600 ~/.u_agents_env.zsh
+   $EDITOR ~/.u_agents_env.zsh   # fill in real RUNNER_ID / MACHINE_ID
+   ```
+
+   `.zshrc` sources `~/.u_agents_env.zsh` when present (guarded, so shells
+   without it are unaffected). The real file lives outside the dotfiles repo
+   and is never committed. Restart the tmux `agents` session after editing so
+   the PM pane inherits the new values.
+
+The `~/.u_agents_env.zsh` file and the plist identities ship with the
+placeholders `runner` / `machine`, which identity validation rejects on
+purpose — a forgotten edit fails loudly instead of claiming work under a bogus
+identity.
+
+### psycopg / Python environment
+
+The live DB client imports `psycopg`. The Python interpreter that runs the
+launcher, watchdog, PR watcher, and `mark_pr_open` must have it installed.
+Install into that interpreter (or a venv it points at) and verify:
+
+```sh
+python3 -m pip install 'psycopg[binary]'
+/opt/homebrew/bin/python3 -c 'import psycopg'   # the interpreter in the plist
+```
+
+If you use a virtualenv, point the plist `ProgramArguments[0]` at that venv's
+interpreter. The PM prompt renders the launcher's `sys.executable` into its
+`mark_pr_open` command, so it will reuse the same psycopg-enabled interpreter.
 
 ## Commands
 
@@ -283,30 +343,151 @@ and resets to empty instead of deadlocking the watchdog loop.
 Stalled-once-and-commented windows do not get re-commented until their pane
 output changes.
 
+### PR-open bookkeeping
+
+The PR watcher only picks up `agent_runs` rows whose `phase` is `pr_open`,
+`pr_watching`, or `ready_to_merge` **and** whose `pr_number` is set. After the
+PM opens a PR it must persist that transition — relying on PM prompt memory is
+not enough, and a missed update strands the run in `pm_started` forever. The PM
+runs the helper CLI from its pane. Because the PM works inside the *target*
+repo worktree (which does not contain the dotfiles `u_agents` package, and
+whose mise/PATH may select a Python without `psycopg`), the command must put
+the dotfiles checkout on `PYTHONPATH` **and** use the runner's own interpreter
+rather than a bare `python3`:
+
+```sh
+PYTHONPATH=/Users/your-name/dotfiles \
+  /opt/homebrew/bin/python3 -m u_agents.mark_pr_open --repo owner/name --issue 233 --pr 240
+```
+
+The PM prompt renders both automatically: `{u_agents_root}` (the dotfiles
+checkout root) and `{u_agents_python}` (the launcher's `sys.executable`, i.e.
+the interpreter that already imported `psycopg`). Both are shell-quoted, so the
+PM never hardcodes them. This advances the row to `phase=pr_open` with
+`pr_number` set (via the same `AgentRunsClient.update_pr_fields` the watcher
+uses), so the next PR-watcher pass takes over. It needs the runner env and
+`psycopg` like the other DB commands (see "Making the env reproducible").
+
+The PM prompt (`prompts/pm.md`) includes this as a required, non-optional step
+right after `gh pr create`.
+
 ### PR Watcher
 
 The PR watcher reads `agent_runs` rows in `pr_open`, `pr_watching`, and
 `ready_to_merge`, then verifies GitHub PR reality before any transition:
 the PR must exist, its head branch must match `branch_name`, and merged/closed,
-CI, and review-comment state are re-read from GitHub.
+CI, and review-comment state are re-read from GitHub. Merged/closed/open state
+is inferred from `gh`'s supported `state` (`OPEN`/`CLOSED`/`MERGED`) and
+`mergedAt` fields — the watcher never requests a `merged` JSON field, which the
+current `gh` CLI does not expose.
 
 ```sh
 python3 -m u_agents.pr_watcher --once
 mise run pr-watcher
 ```
 
-Transition rules:
+It collects both top-level PR comments / review summaries (from `gh pr view`)
+**and** inline review comments attached to specific diff lines (from
+`gh api repos/{owner}/{repo}/pulls/{n}/comments`). The Gemini-style
+high-priority inline note that motivated this is exactly such a comment. If the
+inline-comment fetch fails or returns malformed output, the whole pass is
+deferred (treated as a transient error like a failed `gh pr view`) rather than
+proceeding as if the PR had no inline comments — so a fetch glitch can never
+let a PR reach `ready_to_merge` without its comments being confirmed.
+
+Transition rules (checked in order):
 
 1. Merged PR -> `done`.
-2. Must-fix PR comments with `pr_review_fix_rounds = 0` -> `fixing`, increment
-   `pr_review_fix_rounds`, and assign one automated fix loop.
-3. Must-fix PR comments with `pr_review_fix_rounds >= 1` -> `blocked`.
-4. Green CI and no must-fix comments -> `ready_to_merge`.
-5. Otherwise -> `pr_watching`.
+2. A fresh validated must-fix comment with `pr_review_fix_rounds = 0` ->
+   `fixing`, increment `pr_review_fix_rounds`, mark that comment attempted, and
+   assign one automated fix loop.
+3. A validated must-fix comment already attempted once but still present ->
+   `blocked` (it cannot be auto-fixed again and must not be ignored).
+4. Comments needing user judgment:
+   - With a live dispatcher configured (the production `main()` path) and at
+     least one *fresh* (not-yet-handed-off) key: dispatch a validation prompt
+     to the run's existing PM pane, mark those keys `handed_off`, and park the
+     run in `phase = 'fixing'` (out of the watch set) until the PM re-arms it
+     via `mark_pr_open`. The same key, if still ambiguous on re-entry, is
+     already `handed_off` and falls through to a `blocked` escalation instead
+     of being re-sent every tick.
+   - With no live dispatcher (the conservative default / unit tests), or when
+     every judgment key was already handed off, -> `blocked` (surface the
+     decision to a human).
+5. A fresh validated must-fix comment with `pr_review_fix_rounds >= 1` ->
+   `blocked` (global round cap).
+6. Green CI and no actionable/unresolved/judgment comments -> `ready_to_merge`.
+7. Otherwise -> `pr_watching`.
 
-The watcher records `pr_number`, `pr_review_fix_rounds`, `block_reason`, and
-small observations in `metadata`. It never auto-merges; `ready_to_merge` means
-the user/operator can merge after their own final check.
+#### Validation before fixing
+
+Review comments are not always correct, so the watcher never blindly fixes
+every bot/human comment. **Every** candidate comment — inline review comments,
+top-level PR comments with a must-fix or forward-action signal,
+`CHANGES_REQUESTED` review summaries, and a bare
+`reviewDecision = CHANGES_REQUESTED` — is represented as a review comment and
+flows through the same validation gate. None of them auto-trigger a fix on their
+own. Each is classified as one of:
+
+- `valid_must_fix` — confirmed correct and worth an automated fix.
+- `valid_optional` — fine but not required; no fix.
+- `invalid` — wrong/rejected/already-addressed; recorded, no fix.
+- `needs_user_judgment` — cannot be confirmed automatically. In production the
+  watcher first hands the fresh keys to the existing PM pane for validation (see
+  the live handoff below) and only blocks a key once it has already been
+  handed off and is still ambiguous; without a live dispatcher it blocks
+  immediately so a human decides instead of auto-fixing.
+
+The default runtime classifier (`default_validate_comment`) is deliberately
+conservative and **never** returns `valid_must_fix` from marker text, a
+`CHANGES_REQUESTED` summary, high-priority styling, or bot authorship alone —
+those escalate to `needs_user_judgment`. A real `valid_must_fix` verdict comes
+from an explicit validator (an agent) that the workflow injects. Invalid
+comments record the rejection in metadata; replying on GitHub is a documented
+follow-up, not a test requirement.
+
+#### One automated attempt per comment
+
+Each comment has a stable identity = GitHub comment id + a body hash. The
+watcher persists per-comment state in `agent_runs.metadata.pr_review_comments`
+keyed by that identity (`{verdict, attempted, ...}`), merging forward rather
+than overwriting so a pass that sees an empty/partial comment list cannot drop
+prior `attempted` keys. A `valid_must_fix` comment is auto-fixed at most once:
+once `attempted` is set, the same id+hash on later passes is not fixed again —
+but if it is still present it escalates to `blocked` instead of being ignored.
+If the comment body changes, the hash (and key) changes, so it becomes a new
+validation candidate eligible for one more attempt. This per-comment cap is in
+addition to the global one-round cap (`pr_review_fix_rounds`).
+
+#### Live handoff to the PM pane
+
+The watcher owns no agent of its own. In production (`u_agents.pr_watcher`
+`main()`), when the conservative default escalates a comment to
+`needs_user_judgment`, the watcher hands the *fresh* keys to the run's existing
+PM pane (`run.pm_pane` / `pm_pane_target(run.tmux_window)`) using the same tmux
+delivery the launcher uses to seed the PM. The handoff prompt requires the PM
+to validate each listed comment first, skip invalid/optional comments, address
+only `valid_must_fix` ones, address each `id:body-hash` key at most once,
+record verdicts, and then re-arm the watcher with the **exact** command
+
+    PYTHONPATH=<dotfiles root> <python> -m u_agents.mark_pr_open --repo … --issue … --pr …
+
+(built from the package root and `sys.executable`, never a bare interpreter
+invocation, because the PM runs inside the target repo worktree where
+`u_agents`/`psycopg` may be unavailable).
+
+Duplicate handoffs are prevented by the per-comment `handed_off` flag in
+`metadata.pr_review_comments`: only keys lacking it are dispatched, a successful
+delivery parks the run in `phase = 'fixing'` (so it leaves the watch set while
+the PM works), and a delivery failure leaves the key un-handed-off so it retries
+next pass. Re-arming via `mark_pr_open` (phase -> `pr_open`) brings the run back
+into the watch set; a still-ambiguous, already-`handed_off` key then escalates
+to `blocked` instead of being re-sent.
+
+The watcher records `pr_number`, `pr_review_fix_rounds`, `block_reason`, the
+per-comment triage state, and small observations in `metadata`. It never
+auto-merges; `ready_to_merge` means the user/operator can merge after their own
+final check.
 
 Suggested cron entry (single check per minute):
 
@@ -339,12 +520,29 @@ On macOS, prefer `launchd` over `cron`. Two example plists are tracked in
    ```
 
 2. Edit the four placeholder paths in each plist:
-   - `/opt/homebrew/bin/python3` — your python interpreter
+   - `/opt/homebrew/bin/python3` — your python interpreter (must have `psycopg`)
    - `/Users/your-name/dotfiles/u_agents/config/repositories.yml` — your config
    - `/Users/your-name/dotfiles` — the dotfiles checkout (must contain `u_agents/`)
    - `/Users/your-name/Library/Logs/u-agents-*.log` — log destination
 
-3. Make sure `PATH` in the plist includes the directories holding `gh`,
+3. Edit the `U_AGENTS_*` values under `EnvironmentVariables` in each plist:
+   - `U_AGENTS_DATABASE_URL` — the example ships the local `compose.yml` dev
+     default; change it for any other database.
+   - `U_AGENTS_RUNNER_ID` / `U_AGENTS_MACHINE_ID` — replace the `runner` /
+     `machine` placeholders with real stable identities. Until you do, the job
+     aborts with a "must not be a placeholder identity" error rather than
+     claiming work under a bogus identity.
+
+   Keep these in sync with `~/.u_agents_env.zsh` (the PM pane's copy) so every
+   process agrees on identity. See "Making the env reproducible".
+
+4. Confirm the plist interpreter has `psycopg`:
+
+   ```sh
+   /opt/homebrew/bin/python3 -c 'import psycopg'
+   ```
+
+5. Make sure `PATH` in the plist includes the directories holding `gh`,
    `tmux`, `git`, and `yq`. The examples set `/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin`.
 
 ### Install / start / stop / uninstall
@@ -457,6 +655,7 @@ python3 -m unittest discover tests
 python3 -m u_agents.launcher --help
 python3 -m u_agents.watchdog --help
 python3 -m u_agents.pr_watcher --help
+python3 -m u_agents.mark_pr_open --help
 ```
 
 Live `launcher`, `watchdog`, and `pr_watcher` runs require `gh auth login`, DB

--- a/examples/launchd/local.u-agents.launcher.plist
+++ b/examples/launchd/local.u-agents.launcher.plist
@@ -9,6 +9,19 @@
     /Users/your-name/dotfiles                              (the dotfiles checkout)
     /Users/your-name/Library/Logs/u-agents-launcher.log  (log destination)
 
+  Also edit the U_AGENTS_* values under EnvironmentVariables:
+    U_AGENTS_DATABASE_URL  PostgreSQL URL (the value below is the local
+                           compose.yml dev default; change for any other DB)
+    U_AGENTS_RUNNER_ID     stable runner identity (the placeholder "runner"
+                           is REJECTED on purpose so a forgotten edit fails
+                           loudly instead of running with a bad identity)
+    U_AGENTS_MACHINE_ID    stable machine identity (placeholder "machine" is
+                           likewise rejected until you replace it)
+
+  The interpreter at ProgramArguments[0] must have psycopg installed for the
+  live DB path. Verify with:
+    /opt/homebrew/bin/python3 -c 'import psycopg'
+
   Install:
     cp examples/launchd/local.u-agents.launcher.plist ~/Library/LaunchAgents/
     launchctl load   ~/Library/LaunchAgents/local.u-agents.launcher.plist
@@ -42,6 +55,12 @@
     <dict>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>U_AGENTS_DATABASE_URL</key>
+        <string>postgresql://u_agents:u_agents_dev_password@127.0.0.1:54329/u_agents</string>
+        <key>U_AGENTS_RUNNER_ID</key>
+        <string>runner</string>
+        <key>U_AGENTS_MACHINE_ID</key>
+        <string>machine</string>
     </dict>
 
     <key>StandardOutPath</key>

--- a/examples/launchd/local.u-agents.watchdog.plist
+++ b/examples/launchd/local.u-agents.watchdog.plist
@@ -14,6 +14,13 @@
     /Users/your-name/dotfiles                              (the dotfiles checkout)
     /Users/your-name/Library/Logs/u-agents-watchdog.log  (log destination)
 
+  Also edit the U_AGENTS_* values under EnvironmentVariables (same as the
+  launcher job): U_AGENTS_DATABASE_URL plus the U_AGENTS_RUNNER_ID /
+  U_AGENTS_MACHINE_ID identities. The "runner"/"machine" placeholders are
+  rejected on purpose so a forgotten edit fails loudly. The interpreter at
+  ProgramArguments[0] must have psycopg installed:
+    /opt/homebrew/bin/python3 -c 'import psycopg'
+
   Install:
     cp examples/launchd/local.u-agents.watchdog.plist ~/Library/LaunchAgents/
     launchctl load   ~/Library/LaunchAgents/local.u-agents.watchdog.plist
@@ -51,6 +58,12 @@
     <dict>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>U_AGENTS_DATABASE_URL</key>
+        <string>postgresql://u_agents:u_agents_dev_password@127.0.0.1:54329/u_agents</string>
+        <key>U_AGENTS_RUNNER_ID</key>
+        <string>runner</string>
+        <key>U_AGENTS_MACHINE_ID</key>
+        <string>machine</string>
     </dict>
 
     <key>StandardOutPath</key>

--- a/tests/test_agent_runs.py
+++ b/tests/test_agent_runs.py
@@ -227,6 +227,40 @@ class TestAgentRunsClientWrites(unittest.TestCase):
         self.assertEqual(params["phase"], "fixing")
         self.assertTrue(params["increment_fix_rounds"])
 
+    def test_mark_pr_open_sets_pr_open_phase_and_number(self):
+        conn = FakeConn([_row(phase="pr_open", pr_number=240)])
+        client = AgentRunsClient(conn, self.identity)
+
+        run = client.mark_pr_open("o/r", 12, pr_number=240)
+
+        self.assertEqual(run.phase, "pr_open")
+        self.assertEqual(run.pr_number, 240)
+        _sql, params = conn.calls[0]
+        self.assertEqual(params["phase"], "pr_open")
+        self.assertEqual(params["pr_number"], 240)
+        # PR-open bookkeeping must not consume a review fix round.
+        self.assertFalse(params["increment_fix_rounds"])
+        self.assertEqual(
+            json.loads(params["metadata"]), {"pr_open": {"pr_number": 240}},
+        )
+
+    def test_mark_pr_open_internal_metadata_wins_collision(self):
+        conn = FakeConn([_row(phase="pr_open", pr_number=240)])
+        client = AgentRunsClient(conn, self.identity)
+
+        client.mark_pr_open(
+            "o/r",
+            12,
+            pr_number=240,
+            metadata={"pr_open": {"pr_number": 999}, "source": "test"},
+        )
+
+        _sql, params = conn.calls[0]
+        self.assertEqual(
+            json.loads(params["metadata"]),
+            {"source": "test", "pr_open": {"pr_number": 240}},
+        )
+
     def test_list_active_and_stale_runs_use_domain_phases(self):
         active_conn = FakeConn([_row(phase="pm_started")])
         active_client = AgentRunsClient(active_conn, self.identity)

--- a/tests/test_launchd_examples.py
+++ b/tests/test_launchd_examples.py
@@ -10,6 +10,15 @@ import re
 import unittest
 from pathlib import Path
 
+from u_agents.control_plane import (
+    ENV_DATABASE_URL,
+    ENV_MACHINE_ID,
+    ENV_RUNNER_ID,
+    ConfigError,
+    database_url_from_env,
+    load_runner_identity,
+)
+
 
 EXAMPLES = Path(__file__).resolve().parent.parent / "examples" / "launchd"
 LAUNCHER_PLIST = EXAMPLES / "local.u-agents.launcher.plist"
@@ -114,6 +123,46 @@ class TestWatchdogPlist(unittest.TestCase):
     def test_log_paths_set(self):
         self.assertIn("StandardOutPath", self.plist)
         self.assertIn("StandardErrorPath", self.plist)
+
+
+class TestRequiredRunnerEnv(unittest.TestCase):
+    """Live launcher/watchdog runs need U_AGENTS_* env. The tracked templates
+    must declare those keys so launchd jobs do not silently fail
+    AgentRunsClient.from_env, while keeping identities as loud placeholders.
+    """
+
+    def _env(self, path: Path) -> dict:
+        return _load(path)["EnvironmentVariables"]
+
+    def test_plists_declare_all_required_runner_env_keys(self):
+        for path in (LAUNCHER_PLIST, WATCHDOG_PLIST):
+            with self.subTest(path=path.name):
+                env = self._env(path)
+                for key in (ENV_DATABASE_URL, ENV_RUNNER_ID, ENV_MACHINE_ID):
+                    self.assertIn(key, env, f"{path.name} missing {key}")
+
+    def test_database_url_placeholder_has_valid_scheme(self):
+        for path in (LAUNCHER_PLIST, WATCHDOG_PLIST):
+            with self.subTest(path=path.name):
+                env = self._env(path)
+                # database_url_from_env enforces postgresql:// / postgres://.
+                self.assertEqual(
+                    database_url_from_env({ENV_DATABASE_URL: env[ENV_DATABASE_URL]}),
+                    env[ENV_DATABASE_URL],
+                )
+
+    def test_identity_placeholders_fail_loudly_until_edited(self):
+        # The shipped runner/machine placeholders must be rejected by identity
+        # validation so a forgotten edit aborts with a clear error instead of
+        # claiming work under a bogus identity.
+        for path in (LAUNCHER_PLIST, WATCHDOG_PLIST):
+            with self.subTest(path=path.name):
+                env = self._env(path)
+                with self.assertRaises(ConfigError):
+                    load_runner_identity({
+                        ENV_RUNNER_ID: env[ENV_RUNNER_ID],
+                        ENV_MACHINE_ID: env[ENV_MACHINE_ID],
+                    })
 
 
 class TestNoPersonalPaths(unittest.TestCase):

--- a/tests/test_mark_pr_open.py
+++ b/tests/test_mark_pr_open.py
@@ -1,0 +1,92 @@
+import unittest
+from dataclasses import replace
+from unittest import mock
+
+from u_agents.agent_runs import AgentRun
+from u_agents.mark_pr_open import main, record_pr_open
+
+
+def _run(**overrides):
+    base = AgentRun(
+        repository_full_name="o/r",
+        github_issue_number=12,
+        parent_branch="main",
+        branch_name="feat/12",
+        phase="pr_open",
+        runner_id="runner-1",
+        machine_id="machine-1",
+        locked_by="runner-1@machine-1",
+        lease_until="future",
+        worktree_basename="12",
+        tmux_window="r-12",
+        pm_pane="agents:r-12.0",
+        pr_number=240,
+        metadata={},
+    )
+    return replace(base, **overrides)
+
+
+class FakeDbClient:
+    def __init__(self, run=None):
+        self.run = run or _run()
+        self.calls = []
+        self.closed = False
+
+    def mark_pr_open(self, repo_full, issue_number, *, pr_number, metadata=None):
+        self.calls.append(("mark_pr_open", repo_full, issue_number, pr_number, metadata))
+        return replace(self.run, phase="pr_open", pr_number=pr_number)
+
+    def close(self):
+        self.closed = True
+
+
+class TestRecordPrOpen(unittest.TestCase):
+    def test_delegates_to_client_mark_pr_open(self):
+        db = FakeDbClient()
+
+        run = record_pr_open(db, "o/r", 12, 240)
+
+        self.assertEqual(run.phase, "pr_open")
+        self.assertEqual(run.pr_number, 240)
+        self.assertEqual(db.calls, [("mark_pr_open", "o/r", 12, 240, None)])
+
+
+class TestMain(unittest.TestCase):
+    def test_main_records_pr_open_and_closes_client(self):
+        db = FakeDbClient()
+        with mock.patch(
+            "u_agents.mark_pr_open.AgentRunsClient.from_env", return_value=db,
+        ):
+            rc = main(["--repo", "o/r", "--issue", "12", "--pr", "240"])
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(db.calls, [("mark_pr_open", "o/r", 12, 240, None)])
+        self.assertTrue(db.closed)
+
+    def test_main_closes_client_even_on_error(self):
+        db = FakeDbClient()
+
+        def boom(*_a, **_kw):
+            raise RuntimeError("db down")
+
+        db.mark_pr_open = boom
+        with mock.patch(
+            "u_agents.mark_pr_open.AgentRunsClient.from_env", return_value=db,
+        ):
+            with self.assertRaises(RuntimeError):
+                main(["--repo", "o/r", "--issue", "12", "--pr", "240"])
+        self.assertTrue(db.closed)
+
+    def test_main_requires_repo_issue_and_pr(self):
+        for argv in (
+            ["--issue", "12", "--pr", "240"],
+            ["--repo", "o/r", "--pr", "240"],
+            ["--repo", "o/r", "--issue", "12"],
+        ):
+            with self.subTest(argv=argv):
+                with self.assertRaises(SystemExit):
+                    main(argv)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pm_prompt.py
+++ b/tests/test_pm_prompt.py
@@ -1,0 +1,76 @@
+import shlex
+import sys
+import unittest
+from pathlib import Path
+
+from u_agents.contract import RepoConfig
+from u_agents.launcher import (
+    DEFAULT_PROMPT_TEMPLATE,
+    PACKAGE_DIR,
+    Issue,
+    render_pm_prompt,
+)
+
+PM_PROMPT = Path(__file__).resolve().parent.parent / "u_agents" / "prompts" / "pm.md"
+
+
+class TestPmPromptContent(unittest.TestCase):
+    def setUp(self):
+        self.text = PM_PROMPT.read_text(encoding="utf-8")
+
+    def test_mise_trust_is_conditional(self):
+        # Fix #4: trust must be performed for repos that use mise, but the
+        # prompt must not assume every repo does.
+        self.assertIn("mise trust", self.text)
+        self.assertIn("mise.toml", self.text)
+        self.assertRegex(self.text, r"do not assume every repo uses mise")
+
+    def test_records_pr_open_bookkeeping_via_cli(self):
+        # Fix #2: opening a PR must durably advance agent_runs, not rely on
+        # prompt memory.
+        self.assertIn("u_agents.mark_pr_open", self.text)
+        self.assertIn("phase=pr_open", self.text)
+
+    def test_pr_open_command_uses_explicit_package_root_and_python(self):
+        # The PM runs from the target repo worktree, which has no u_agents on
+        # the path and may have a psycopg-less Python on PATH. The command must
+        # carry both an explicit PYTHONPATH and the explicit runtime
+        # interpreter placeholder (not a bare `python3`).
+        self.assertIn(
+            "PYTHONPATH={u_agents_root} {u_agents_python} -m u_agents.mark_pr_open",
+            self.text,
+        )
+
+
+class TestPmPromptRenders(unittest.TestCase):
+    """The whole template must still render: every {placeholder} added for the
+    new steps must exist in the launcher's mapping (no KeyError)."""
+
+    def _issue(self):
+        repo = RepoConfig("o/r", "/workspace/r", "main")
+        return Issue(repo=repo, number=233, title="t", url="http://x/233", labels=[])
+
+    def test_renders_without_unknown_placeholders(self):
+        rendered = render_pm_prompt(DEFAULT_PROMPT_TEMPLATE, self._issue(), "r-233")
+        # The rendered command must carry the substituted (shell-quoted) package
+        # root AND the explicit runtime interpreter, so it is runnable from the
+        # target worktree with a psycopg-enabled Python.
+        expected_root = shlex.quote(str(PACKAGE_DIR.parent))
+        expected_python = shlex.quote(sys.executable)
+        self.assertIn(
+            f"PYTHONPATH={expected_root} {expected_python} "
+            f"-m u_agents.mark_pr_open --repo o/r --issue 233 --pr",
+            rendered,
+        )
+        # The interpreter must be the launcher's own sys.executable, not a bare
+        # `python3`.
+        self.assertIn(sys.executable, rendered)
+        # Placeholders must be fully substituted (no leftover braces).
+        self.assertNotIn("{u_agents_root}", rendered)
+        self.assertNotIn("{u_agents_python}", rendered)
+        # Literal placeholder for the PR number is left for the PM to fill.
+        self.assertIn("<pr-number>", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr_watcher.py
+++ b/tests/test_pr_watcher.py
@@ -1,18 +1,40 @@
 import json
 import subprocess
+import sys
 import unittest
 from dataclasses import replace
 from unittest import mock
 
 from u_agents.agent_runs import AgentRun
 from u_agents.pr_watcher import (
+    PR_VIEW_JSON_FIELDS,
+    REVIEW_VERDICTS,
     PrReality,
+    ReviewComment,
     _status_checks_green,
+    build_fix_prompt,
+    build_validation_handoff_prompt,
     check_once,
+    default_validate_comment,
     extract_must_fix_review_comment_keys,
     fetch_pr_reality,
+    fetch_review_comments,
+    live_dispatch_handoff,
+    mark_pr_open_command,
     reconcile_pr_run,
+    triage_review_comments,
 )
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+def _inline_proc(items=None):
+    """A successful `gh api .../comments` response (a JSON array)."""
+    return _completed(returncode=0, stdout=json.dumps(items or []))
 
 
 def _run(**overrides):
@@ -253,36 +275,41 @@ class TestPrWatcherTransitions(unittest.TestCase):
         self.assertEqual(db.calls[0][0], "done")
 
     def test_first_must_fix_round_updates_then_assigns_fix(self):
+        # A validated must-fix comment (validator returns valid_must_fix) drives
+        # the first fix round. The legacy must_fix_review_comments flag alone
+        # must NOT trigger fixing (it is routed through validation instead).
         db = FakeDbClient([_run(pr_review_fix_rounds=0)])
+        c = ReviewComment(comment_id="c1", body="please fix", source="inline")
         assignments = []
 
         updated = reconcile_pr_run(
             db.runs[0],
-            _reality(
-                must_fix_review_comments=True,
-                must_fix_comment_keys=("comment:c1",),
-            ),
+            _reality(review_comments=(c,)),
             db,
             assign_fix=lambda run, reality: assignments.append(
-                (run.pr_review_fix_rounds, reality.must_fix_comment_keys)
+                run.pr_review_fix_rounds
             ),
+            validate_comment=lambda _c: "valid_must_fix",
         )
 
         self.assertEqual(updated.phase, "fixing")
         self.assertEqual(updated.pr_review_fix_rounds, 1)
         self.assertEqual(db.calls[0][0], "update_pr_fields")
         self.assertTrue(db.calls[0][5])
-        self.assertEqual(assignments, [(1, ("comment:c1",))])
+        self.assertEqual(assignments, [1])
 
     def test_second_must_fix_round_blocks_without_assignment(self):
+        # Round cap: a fresh validated must-fix with the budget exhausted blocks.
         db = FakeDbClient([_run(pr_review_fix_rounds=1)])
+        c = ReviewComment(comment_id="c1", body="please fix", source="inline")
         assignments = []
 
         updated = reconcile_pr_run(
             db.runs[0],
-            _reality(must_fix_review_comments=True),
+            _reality(review_comments=(c,)),
             db,
             assign_fix=lambda *_args: assignments.append("assigned"),
+            validate_comment=lambda _c: "valid_must_fix",
         )
 
         self.assertEqual(updated.phase, "blocked")
@@ -332,14 +359,8 @@ class TestPrWatcherTransitions(unittest.TestCase):
 class TestFetchPrReality(unittest.TestCase):
     """Comment 3: definitive not-found vs transient/parse failures."""
 
-    @staticmethod
-    def _completed(returncode=0, stdout="", stderr=""):
-        return subprocess.CompletedProcess(
-            args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr,
-        )
-
     def test_definitive_not_found_returns_exists_false(self):
-        proc = self._completed(
+        proc = _completed(
             returncode=1,
             stderr="GraphQL: Could not resolve to a PullRequest with the number of 999.",
         )
@@ -350,7 +371,7 @@ class TestFetchPrReality(unittest.TestCase):
         self.assertEqual(reality.pr_number, 999)
 
     def test_transient_failure_raises_runtime_error(self):
-        proc = self._completed(
+        proc = _completed(
             returncode=1,
             stderr="error connecting to api.github.com: dial tcp: i/o timeout",
         )
@@ -360,7 +381,7 @@ class TestFetchPrReality(unittest.TestCase):
 
     def test_dns_resolution_failure_is_transient_not_absence(self):
         # "Could not resolve host" is a DNS/network error, not a missing PR.
-        proc = self._completed(
+        proc = _completed(
             returncode=1, stderr="Could not resolve host: api.github.com",
         )
         with mock.patch("u_agents.pr_watcher._run", return_value=proc):
@@ -368,7 +389,7 @@ class TestFetchPrReality(unittest.TestCase):
                 fetch_pr_reality("o/r", 45)
 
     def test_malformed_json_raises_runtime_error(self):
-        proc = self._completed(returncode=0, stdout="<html>500</html>")
+        proc = _completed(returncode=0, stdout="<html>500</html>")
         with mock.patch("u_agents.pr_watcher._run", return_value=proc):
             with self.assertRaises(RuntimeError):
                 fetch_pr_reality("o/r", 45)
@@ -388,7 +409,7 @@ class TestFetchPrReality(unittest.TestCase):
         })
         with mock.patch(
             "u_agents.pr_watcher._run",
-            return_value=self._completed(returncode=0, stdout=payload),
+            side_effect=[_completed(returncode=0, stdout=payload), _inline_proc()],
         ):
             reality = fetch_pr_reality("o/r", 45)
 
@@ -397,6 +418,736 @@ class TestFetchPrReality(unittest.TestCase):
         self.assertEqual(reality.head_branch, "feat/12")
         self.assertTrue(reality.ci_green)
         self.assertFalse(reality.must_fix_review_comments)
+
+
+class TestGhFieldCompatibility(unittest.TestCase):
+    """The current gh CLI has no `merged` JSON field; requesting it errors with
+    `Unknown JSON field: "merged"`. The watcher must only ask for supported
+    fields and infer merged/closed/open from `state`/`mergedAt`.
+    """
+
+    @staticmethod
+    def _payload(**overrides):
+        base = {
+            "number": 45,
+            "headRefName": "feat/12",
+            "state": "OPEN",
+            "mergedAt": None,
+            "statusCheckRollup": [],
+            "reviewDecision": None,
+            "comments": [],
+            "latestReviews": [],
+        }
+        base.update(overrides)
+        return json.dumps(base)
+
+    def _captured_json_fields(self):
+        """Run fetch_pr_reality and return the parsed `--json` field set.
+
+        fetch_pr_reality issues more than one gh call (pr view + inline review
+        comments), so scan all calls for the one carrying `--json`.
+        """
+        captured = {"cmds": []}
+
+        def fake_run(cmd):
+            captured["cmds"].append(cmd)
+            if "api" in cmd:
+                return _inline_proc()
+            return _completed(returncode=0, stdout=self._payload())
+
+        with mock.patch("u_agents.pr_watcher._run", side_effect=fake_run):
+            fetch_pr_reality("o/r", 45)
+        pr_view_cmds = [c for c in captured["cmds"] if "--json" in c]
+        cmd = pr_view_cmds[0]
+        idx = cmd.index("--json")
+        return set(cmd[idx + 1].split(","))
+
+    def test_does_not_request_unsupported_merged_field(self):
+        fields = self._captured_json_fields()
+        # `merged` is a substring of `mergedAt`, so compare the exact field set.
+        self.assertNotIn("merged", fields)
+
+    def test_requests_supported_merge_state_fields(self):
+        fields = self._captured_json_fields()
+        self.assertIn("mergedAt", fields)
+        self.assertIn("state", fields)
+        # The module constant and the actual request must stay in sync.
+        self.assertEqual(fields, set(PR_VIEW_JSON_FIELDS))
+
+    def test_module_field_list_excludes_merged(self):
+        self.assertNotIn("merged", PR_VIEW_JSON_FIELDS)
+        self.assertIn("mergedAt", PR_VIEW_JSON_FIELDS)
+
+    def test_merged_state_infers_merged_true(self):
+        proc = _completed(returncode=0, stdout=self._payload(state="MERGED"))
+        with mock.patch(
+            "u_agents.pr_watcher._run", side_effect=[proc, _inline_proc()],
+        ):
+            reality = fetch_pr_reality("o/r", 45)
+        self.assertTrue(reality.merged)
+        self.assertFalse(reality.closed)
+
+    def test_merged_at_timestamp_infers_merged_true(self):
+        proc = _completed(
+            returncode=0,
+            stdout=self._payload(state="MERGED", mergedAt="2026-01-01T00:00:00Z"),
+        )
+        with mock.patch(
+            "u_agents.pr_watcher._run", side_effect=[proc, _inline_proc()],
+        ):
+            reality = fetch_pr_reality("o/r", 45)
+        self.assertTrue(reality.merged)
+
+    def test_closed_unmerged_state_infers_closed(self):
+        proc = _completed(returncode=0, stdout=self._payload(state="CLOSED"))
+        with mock.patch(
+            "u_agents.pr_watcher._run", side_effect=[proc, _inline_proc()],
+        ):
+            reality = fetch_pr_reality("o/r", 45)
+        self.assertFalse(reality.merged)
+        self.assertTrue(reality.closed)
+
+    def test_open_state_is_neither_merged_nor_closed(self):
+        proc = _completed(returncode=0, stdout=self._payload(state="OPEN"))
+        with mock.patch(
+            "u_agents.pr_watcher._run", side_effect=[proc, _inline_proc()],
+        ):
+            reality = fetch_pr_reality("o/r", 45)
+        self.assertFalse(reality.merged)
+        self.assertFalse(reality.closed)
+
+
+class TestInlineReviewCommentCollection(unittest.TestCase):
+    """Inline PR review comments (per-file/line) come from a separate gh API
+    call, not `gh pr view`. They must be represented in PrReality."""
+
+    @staticmethod
+    def _pr_view(**overrides):
+        base = {
+            "number": 45, "headRefName": "feat/12", "state": "OPEN",
+            "mergedAt": None, "statusCheckRollup": [], "reviewDecision": None,
+            "comments": [], "latestReviews": [],
+        }
+        base.update(overrides)
+        return _completed(returncode=0, stdout=json.dumps(base))
+
+    def test_inline_review_comments_collected_into_reality(self):
+        inline = [{
+            "id": 3348968705,
+            "body": "`ref.read` after `await purchaseNotifier.purchaseProduct()` "
+                    "should be guarded with `context.mounted`.",
+            "path": "lib/views/organisms/purchases/purchase_offer_view.dart",
+            "line": 144,
+            "user": {"login": "gemini-code-assist[bot]", "type": "Bot"},
+        }]
+        with mock.patch(
+            "u_agents.pr_watcher._run",
+            side_effect=[self._pr_view(), _completed(0, json.dumps(inline))],
+        ):
+            reality = fetch_pr_reality("o/r", 45)
+
+        inline_cs = [c for c in reality.review_comments if c.source == "inline"]
+        self.assertEqual(len(inline_cs), 1)
+        c = inline_cs[0]
+        self.assertEqual(c.comment_id, "3348968705")
+        self.assertEqual(
+            c.path, "lib/views/organisms/purchases/purchase_offer_view.dart",
+        )
+        self.assertEqual(c.line, 144)
+        self.assertEqual(c.author_type, "Bot")
+
+    def test_inline_fetch_api_failure_raises_transient(self):
+        # An inline-comment API failure is ambiguous (the PR exists), so it must
+        # raise so check_once defers instead of proceeding as if there were no
+        # inline comments to validate.
+        with mock.patch(
+            "u_agents.pr_watcher._run",
+            side_effect=[self._pr_view(), _completed(returncode=1, stderr="boom")],
+        ):
+            with self.assertRaises(RuntimeError):
+                fetch_pr_reality("o/r", 45)
+
+    def test_inline_fetch_malformed_json_raises(self):
+        with mock.patch(
+            "u_agents.pr_watcher._run",
+            side_effect=[self._pr_view(), _completed(0, "<html>500</html>")],
+        ):
+            with self.assertRaises(RuntimeError):
+                fetch_pr_reality("o/r", 45)
+
+    def test_fetch_review_comments_raises_on_non_list(self):
+        with mock.patch(
+            "u_agents.pr_watcher._run",
+            return_value=_completed(0, json.dumps({"message": "Not Found"})),
+        ):
+            with self.assertRaises(RuntimeError):
+                fetch_review_comments("o/r", 45)
+
+    def test_check_once_defers_when_inline_fetch_raises(self):
+        # Failure to confirm inline comments must not mutate DB state.
+        db = FakeDbClient([_run(phase="ready_to_merge")])
+
+        def boom(_repo, _pr):
+            raise RuntimeError("gh api inline review comments failed")
+
+        updated = check_once(db, fetch_reality=boom)
+        self.assertEqual(updated, [])
+        self.assertEqual(db.calls, [])
+
+
+class TestDefaultValidationGate(unittest.TestCase):
+    def test_high_priority_bot_comment_is_not_auto_valid_must_fix(self):
+        # A Gemini-style high-priority inline comment must be collected but the
+        # runtime must NOT classify it valid_must_fix from styling/author alone.
+        c = ReviewComment(
+            comment_id="3348968705",
+            body="![high priority](badge.svg) `ref.read` after `await` should be "
+                 "guarded with `context.mounted`.",
+            source="inline", path="x.dart", line=144,
+            author="gemini-code-assist[bot]", author_type="Bot",
+        )
+        verdict = default_validate_comment(c)
+        self.assertIn(verdict, REVIEW_VERDICTS)
+        self.assertNotEqual(verdict, "valid_must_fix")
+
+    def test_default_never_returns_valid_must_fix(self):
+        for body in (
+            "must-fix: handle missing state",
+            "this is blocking",
+            "changes requested",
+            "just a thought",
+        ):
+            c = ReviewComment(comment_id="1", body=body, source="inline")
+            self.assertNotEqual(default_validate_comment(c), "valid_must_fix")
+
+    def test_optional_and_resolved_markers(self):
+        opt = ReviewComment(comment_id="1", body="nit: rename this", source="inline")
+        done = ReviewComment(comment_id="2", body="already addressed", source="inline")
+        self.assertEqual(default_validate_comment(opt), "valid_optional")
+        self.assertEqual(default_validate_comment(done), "invalid")
+
+
+class TestReviewCommentTriage(unittest.TestCase):
+    def _c(self, body="please fix this", cid="111"):
+        return ReviewComment(comment_id=cid, body=body, source="inline", path="a.dart", line=1)
+
+    def test_valid_must_fix_is_actionable_when_unattempted(self):
+        c = self._c()
+        t = triage_review_comments([c], {}, lambda _c: "valid_must_fix")
+        self.assertIn(c.stable_key, t.actionable_keys)
+        self.assertEqual(t.bookkeeping[c.stable_key]["verdict"], "valid_must_fix")
+        self.assertFalse(t.bookkeeping[c.stable_key]["attempted"])
+
+    def test_attempted_key_is_not_actionable_again(self):
+        c = self._c()
+        prior = {c.stable_key: {"verdict": "valid_must_fix", "attempted": True}}
+        t = triage_review_comments([c], prior, lambda _c: "valid_must_fix")
+        self.assertEqual(t.actionable_keys, [])
+        # attempted state is preserved.
+        self.assertTrue(t.bookkeeping[c.stable_key]["attempted"])
+
+    def test_changed_body_becomes_new_candidate(self):
+        c1 = self._c(body="old body")
+        prior = {c1.stable_key: {"verdict": "valid_must_fix", "attempted": True}}
+        c2 = self._c(body="new different body")  # same id, new body -> new key
+        self.assertNotEqual(c1.stable_key, c2.stable_key)
+        t = triage_review_comments([c2], prior, lambda _c: "valid_must_fix")
+        self.assertIn(c2.stable_key, t.actionable_keys)
+        self.assertFalse(t.bookkeeping[c2.stable_key]["attempted"])
+
+    def test_invalid_and_optional_are_not_actionable(self):
+        ci = self._c(body="resolved already", cid="1")
+        co = self._c(body="nit", cid="2")
+        t = triage_review_comments(
+            [ci, co], {},
+            lambda c: "invalid" if c.comment_id == "1" else "valid_optional",
+        )
+        self.assertEqual(t.actionable_keys, [])
+        self.assertEqual(t.needs_judgment_keys, [])
+        self.assertIn(ci.stable_key, t.invalid_keys)
+        self.assertIn(co.stable_key, t.optional_keys)
+
+    def test_needs_user_judgment_collected(self):
+        c = self._c()
+        t = triage_review_comments([c], {}, lambda _c: "needs_user_judgment")
+        self.assertIn(c.stable_key, t.needs_judgment_keys)
+        self.assertEqual(t.actionable_keys, [])
+
+
+class TestValidatedCommentReconcile(unittest.TestCase):
+    def _inline(self, cid="111", body="please fix this", **o):
+        return ReviewComment(
+            comment_id=cid, body=body, source="inline", path="a.dart", line=1, **o,
+        )
+
+    def test_validated_must_fix_triggers_one_fix_attempt(self):
+        db = FakeDbClient([_run(pr_review_fix_rounds=0)])
+        c = self._inline()
+        assignments = []
+
+        updated = reconcile_pr_run(
+            db.runs[0],
+            _reality(review_comments=(c,)),
+            db,
+            assign_fix=lambda run, reality: assignments.append(reality),
+            validate_comment=lambda _c: "valid_must_fix",
+        )
+
+        self.assertEqual(updated.phase, "fixing")
+        self.assertEqual(updated.pr_review_fix_rounds, 1)
+        self.assertEqual(len(assignments), 1)
+        self.assertEqual(db.calls[0][0], "update_pr_fields")
+        self.assertTrue(db.calls[0][5])  # increment_fix_rounds
+        meta = db.calls[0][-1]
+        entry = meta["pr_review_comments"][c.stable_key]
+        self.assertEqual(entry["verdict"], "valid_must_fix")
+        self.assertTrue(entry["attempted"])
+
+    def test_same_comment_not_fixed_twice_and_not_ready_to_merge(self):
+        # Finding 2: a valid must-fix already attempted once and still present
+        # must NOT slip to ready_to_merge even with green CI, and must NOT get a
+        # second fix; it escalates to a human instead.
+        c = self._inline()
+        run = _run(
+            pr_review_fix_rounds=1,
+            metadata={"pr_review_comments": {
+                c.stable_key: {"verdict": "valid_must_fix", "attempted": True},
+            }},
+        )
+        db = FakeDbClient([run])
+        assignments = []
+
+        updated = reconcile_pr_run(
+            run,
+            _reality(review_comments=(c,), ci_green=True),
+            db,
+            assign_fix=lambda *a: assignments.append(a),
+            validate_comment=lambda _c: "valid_must_fix",
+        )
+
+        self.assertEqual(updated.phase, "blocked")
+        self.assertEqual(assignments, [])
+        self.assertEqual(db.calls[0][0], "blocked")
+        self.assertIn("remain after", db.calls[0][3].lower())
+
+    def test_changed_body_can_be_fixed_again_as_new_candidate(self):
+        old = self._inline(body="old advice")
+        new = self._inline(body="new advice entirely")
+        run = _run(
+            pr_review_fix_rounds=0,
+            metadata={"pr_review_comments": {
+                old.stable_key: {"verdict": "valid_must_fix", "attempted": True},
+            }},
+        )
+        db = FakeDbClient([run])
+        assignments = []
+
+        updated = reconcile_pr_run(
+            run,
+            _reality(review_comments=(new,)),
+            db,
+            assign_fix=lambda run, reality: assignments.append(reality),
+            validate_comment=lambda _c: "valid_must_fix",
+        )
+
+        self.assertEqual(updated.phase, "fixing")
+        self.assertEqual(len(assignments), 1)
+
+    def test_needs_user_judgment_blocks(self):
+        db = FakeDbClient([_run()])
+        c = self._inline()
+        updated = reconcile_pr_run(
+            db.runs[0],
+            _reality(review_comments=(c,)),
+            db,
+            validate_comment=lambda _c: "needs_user_judgment",
+        )
+
+        self.assertEqual(updated.phase, "blocked")
+        self.assertEqual(db.calls[0][0], "blocked")
+        self.assertIn("user judgment", db.calls[0][3].lower())
+
+    def test_invalid_inline_comment_does_not_block_or_fix(self):
+        db = FakeDbClient([_run(pr_review_fix_rounds=0)])
+        c = self._inline(body="this suggestion is wrong")
+        updated = reconcile_pr_run(
+            db.runs[0],
+            _reality(review_comments=(c,), ci_green=True),
+            db,
+            assign_fix=lambda *a: self.fail("must not assign fix for invalid comment"),
+            validate_comment=lambda _c: "invalid",
+        )
+
+        self.assertEqual(updated.phase, "ready_to_merge")
+
+    def test_merged_pr_wins_over_needs_user_judgment(self):
+        db = FakeDbClient([_run()])
+        c = self._inline()
+        updated = reconcile_pr_run(
+            db.runs[0],
+            _reality(merged=True, closed=True, review_comments=(c,)),
+            db,
+            validate_comment=lambda _c: "needs_user_judgment",
+        )
+        self.assertEqual(updated.phase, "done")
+
+
+class TestLegacyCommentsRoutedThroughValidation(unittest.TestCase):
+    """Finding 1: top-level comments, latestReviews, and a CHANGES_REQUESTED
+    reviewDecision must pass through the validation gate, not auto-trigger a
+    fix. Marker text / CHANGES_REQUESTED summaries are never auto valid_must_fix.
+    """
+
+    @staticmethod
+    def _pr_view(**overrides):
+        base = {
+            "number": 45, "headRefName": "feat/12", "state": "OPEN",
+            "mergedAt": None, "statusCheckRollup": [], "reviewDecision": None,
+            "comments": [], "latestReviews": [],
+        }
+        base.update(overrides)
+        return _completed(returncode=0, stdout=json.dumps(base))
+
+    def _reality_with(self, **pr_overrides):
+        with mock.patch(
+            "u_agents.pr_watcher._run",
+            side_effect=[self._pr_view(**pr_overrides), _inline_proc()],
+        ):
+            return fetch_pr_reality("o/r", 45)
+
+    def test_top_level_must_fix_comment_collected_as_review_comment(self):
+        reality = self._reality_with(
+            comments=[{"id": "c9", "body": "must-fix: guard context.mounted"}],
+        )
+        srcs = {c.source for c in reality.review_comments}
+        self.assertIn("comment", srcs)
+
+    def test_top_level_forward_action_comment_collected_and_handed_off(self):
+        reality = self._reality_with(
+            comments=[{"id": "c10", "body": "This must be addressed before merge"}],
+        )
+        comments = [c for c in reality.review_comments if c.source == "comment"]
+        self.assertEqual(len(comments), 1)
+        self.assertEqual(default_validate_comment(comments[0]), "needs_user_judgment")
+        db = FakeDbClient([_run(phase="pr_watching")])
+        handoffs = []
+
+        updated = reconcile_pr_run(
+            db.runs[0],
+            reality,
+            db,
+            dispatch_handoff=lambda _run, _reality, keys: handoffs.append(list(keys)) or True,
+        )
+
+        self.assertEqual(updated.phase, "fixing")
+        self.assertEqual(handoffs, [[comments[0].stable_key]])
+
+    def test_latest_review_forward_action_summary_collected(self):
+        reality = self._reality_with(
+            latestReviews=[{
+                "id": "r3",
+                "state": "COMMENTED",
+                "body": "blocking bug should be resolved",
+            }],
+        )
+        reviews = [c for c in reality.review_comments if c.source == "latest_review"]
+        self.assertEqual(len(reviews), 1)
+        self.assertEqual(default_validate_comment(reviews[0]), "needs_user_judgment")
+
+    def test_top_level_must_fix_comment_does_not_auto_fix_under_default(self):
+        reality = self._reality_with(
+            comments=[{"id": "c9", "body": "must-fix: guard context.mounted"}],
+        )
+        db = FakeDbClient([_run(pr_review_fix_rounds=0)])
+        updated = reconcile_pr_run(db.runs[0], reality, db)
+        # Escalated for validation, never auto-fixed from marker text alone.
+        self.assertEqual(updated.phase, "blocked")
+        self.assertNotEqual(db.calls[0][0], "update_pr_fields")
+        self.assertIn("user judgment", db.calls[0][3].lower())
+
+    def test_top_level_must_fix_comment_not_fixed_when_validator_rejects(self):
+        reality = self._reality_with(
+            comments=[{"id": "c9", "body": "must-fix: guard context.mounted"}],
+        )
+        for verdict in ("invalid", "valid_optional"):
+            with self.subTest(verdict=verdict):
+                db = FakeDbClient([_run(pr_review_fix_rounds=0)])
+                updated = reconcile_pr_run(
+                    db.runs[0], replace(reality, ci_green=True), db,
+                    assign_fix=lambda *a: self.fail("must not fix a rejected comment"),
+                    validate_comment=lambda _c: verdict,
+                )
+                self.assertEqual(updated.phase, "ready_to_merge")
+
+    def test_changes_requested_review_decision_escalates(self):
+        reality = self._reality_with(reviewDecision="CHANGES_REQUESTED")
+        sentinels = [c for c in reality.review_comments if c.source == "review_decision"]
+        self.assertEqual(len(sentinels), 1)
+        db = FakeDbClient([_run()])
+        updated = reconcile_pr_run(db.runs[0], reality, db)
+        self.assertEqual(updated.phase, "blocked")
+        self.assertIn("user judgment", db.calls[0][3].lower())
+
+    def test_changes_requested_latest_review_escalates_not_fixes(self):
+        reality = self._reality_with(
+            latestReviews=[{"id": "r2", "state": "CHANGES_REQUESTED", "body": "fix"}],
+        )
+        db = FakeDbClient([_run()])
+        updated = reconcile_pr_run(db.runs[0], reality, db)
+        self.assertEqual(updated.phase, "blocked")
+        self.assertNotEqual(db.calls[0][0], "update_pr_fields")
+
+    def test_changes_requested_state_validates_to_needs_user_judgment(self):
+        c = ReviewComment(
+            comment_id="rd", body="", source="review_decision",
+            state="CHANGES_REQUESTED",
+        )
+        self.assertEqual(default_validate_comment(c), "needs_user_judgment")
+
+    def test_approved_empty_review_is_optional_not_escalated(self):
+        c = ReviewComment(
+            comment_id="r1", body="", source="latest_review", state="APPROVED",
+        )
+        self.assertEqual(default_validate_comment(c), "valid_optional")
+
+
+class TestBookkeepingMerge(unittest.TestCase):
+    """Finding 4: prior per-comment attempted state must survive a pass that
+    sees an empty or unrelated comment list."""
+
+    def test_prior_attempted_key_preserved_when_no_current_comments(self):
+        prior = {"111:abc": {"verdict": "valid_must_fix", "attempted": True}}
+        t = triage_review_comments([], prior, lambda _c: "valid_must_fix")
+        self.assertIn("111:abc", t.bookkeeping)
+        self.assertTrue(t.bookkeeping["111:abc"]["attempted"])
+
+    def test_prior_key_preserved_alongside_unrelated_current_comment(self):
+        prior = {"111:abc": {"verdict": "valid_must_fix", "attempted": True}}
+        other = ReviewComment(comment_id="222", body="new note", source="inline")
+        t = triage_review_comments([other], prior, lambda _c: "valid_optional")
+        self.assertIn("111:abc", t.bookkeeping)
+        self.assertTrue(t.bookkeeping["111:abc"]["attempted"])
+        self.assertIn(other.stable_key, t.bookkeeping)
+
+    def test_reconcile_persists_prior_attempted_key_with_empty_comments(self):
+        prior_key = "111:abc"
+        run = _run(
+            phase="pr_open",
+            metadata={"pr_review_comments": {
+                prior_key: {"verdict": "valid_must_fix", "attempted": True},
+            }},
+        )
+        db = FakeDbClient([run])
+        reconcile_pr_run(run, _reality(review_comments=()), db)
+        meta = db.calls[0][-1]
+        self.assertIn(prior_key, meta["pr_review_comments"])
+        self.assertTrue(meta["pr_review_comments"][prior_key]["attempted"])
+
+
+class TestLiveValidationHandoff(unittest.TestCase):
+    """Finding 1: the live watcher must dispatch needs_user_judgment comments to
+    the existing PM pane (not dead-end), and must not re-send the same stable
+    keys every tick."""
+
+    def _inline(self, cid="111", body="please look at this", **o):
+        return ReviewComment(
+            comment_id=cid, body=body, source="inline", path="a.dart", line=7, **o,
+        )
+
+    def test_fresh_needs_judgment_is_handed_off_not_blocked(self):
+        db = FakeDbClient([_run(phase="pr_watching")])
+        c = self._inline()
+        handoffs = []
+
+        updated = reconcile_pr_run(
+            db.runs[0],
+            _reality(review_comments=(c,)),
+            db,
+            dispatch_handoff=lambda run, reality, keys: handoffs.append(list(keys)) or True,
+            validate_comment=lambda _c: "needs_user_judgment",
+        )
+
+        # Dispatched, parked in 'fixing', recorded handed_off, NOT blocked.
+        self.assertEqual(handoffs, [[c.stable_key]])
+        self.assertEqual(updated.phase, "fixing")
+        self.assertEqual(db.calls[0][0], "update_pr_fields")
+        meta = db.calls[0][-1]
+        self.assertTrue(meta["pr_review_comments"][c.stable_key]["handed_off"])
+        self.assertIn(
+            c.stable_key,
+            meta["pr_watcher"]["review_comment_triage"]["handed_off"],
+        )
+
+    def test_already_handed_off_key_escalates_instead_of_resending(self):
+        c = self._inline()
+        run = _run(
+            phase="pr_watching",
+            metadata={"pr_review_comments": {
+                c.stable_key: {"verdict": "needs_user_judgment", "handed_off": True},
+            }},
+        )
+        db = FakeDbClient([run])
+        handoffs = []
+
+        updated = reconcile_pr_run(
+            run,
+            _reality(review_comments=(c,)),
+            db,
+            dispatch_handoff=lambda *a: handoffs.append(a) or True,
+            validate_comment=lambda _c: "needs_user_judgment",
+        )
+
+        # Not re-sent; escalated to a human block.
+        self.assertEqual(handoffs, [])
+        self.assertEqual(updated.phase, "blocked")
+        self.assertEqual(db.calls[0][0], "blocked")
+        self.assertIn("user judgment", db.calls[0][3].lower())
+
+    def test_delivery_failure_does_not_mark_handed_off(self):
+        db = FakeDbClient([_run(phase="pr_watching")])
+        c = self._inline()
+
+        updated = reconcile_pr_run(
+            db.runs[0],
+            _reality(review_comments=(c,)),
+            db,
+            dispatch_handoff=lambda *a: False,  # delivery failed
+            validate_comment=lambda _c: "needs_user_judgment",
+        )
+
+        # Keep watching and retry; handed_off must stay unset so it is re-tried.
+        self.assertEqual(updated.phase, "pr_watching")
+        meta = db.calls[0][-1]
+        self.assertFalse(meta["pr_review_comments"][c.stable_key]["handed_off"])
+
+    def test_without_dispatcher_default_still_blocks(self):
+        db = FakeDbClient([_run(phase="pr_watching")])
+        c = self._inline()
+        updated = reconcile_pr_run(
+            db.runs[0],
+            _reality(review_comments=(c,)),
+            db,
+            validate_comment=lambda _c: "needs_user_judgment",
+        )
+        self.assertEqual(updated.phase, "blocked")
+
+    def test_check_once_threads_dispatch_handoff_to_reconcile(self):
+        # The production path used by main()/check_once must reach reconcile's
+        # dispatch branch, not just be wired in tests of reconcile directly.
+        db = FakeDbClient([_run(phase="pr_watching")])
+        c = self._inline()
+        handoffs = []
+
+        updated = check_once(
+            db,
+            fetch_reality=lambda repo, pr: _reality(review_comments=(c,)),
+            dispatch_handoff=lambda run, reality, keys: handoffs.append(list(keys)) or True,
+            validate_comment=lambda _c: "needs_user_judgment",
+        )
+
+        self.assertEqual(handoffs, [[c.stable_key]])
+        self.assertEqual(updated[0].phase, "fixing")
+
+    def test_live_dispatch_handoff_sends_prompt_via_tmux(self):
+        run = _run(phase="pr_watching")
+        c = self._inline()
+        reality = _reality(review_comments=(c,))
+        sent = {}
+
+        def fake_send_prompt(window, prompt, dry_run):
+            sent["window"] = window
+            sent["prompt"] = prompt
+            sent["dry_run"] = dry_run
+
+        with mock.patch("u_agents.launcher.send_prompt", side_effect=fake_send_prompt):
+            ok = live_dispatch_handoff(run, reality, [c.stable_key])
+
+        self.assertTrue(ok)
+        self.assertEqual(sent["window"], run.tmux_window)
+        self.assertFalse(sent["dry_run"])
+        self.assertIn(c.stable_key, sent["prompt"])
+
+    def test_live_dispatch_handoff_returns_false_on_tmux_error(self):
+        run = _run(phase="pr_watching")
+        reality = _reality(review_comments=(self._inline(),))
+        with mock.patch(
+            "u_agents.launcher.send_prompt",
+            side_effect=RuntimeError("pane is dead"),
+        ):
+            ok = live_dispatch_handoff(run, reality, [self._inline().stable_key])
+        self.assertFalse(ok)
+
+    def test_handoff_prompt_demands_validation_and_at_most_once(self):
+        run = _run()
+        c = self._inline(body="ref.read after await should be guarded")
+        prompt = build_validation_handoff_prompt(
+            run, _reality(review_comments=(c,)), [c.stable_key],
+        )
+        self.assertIn(c.stable_key, prompt)
+        self.assertIn("Validate each", prompt)
+        self.assertIn("at most once", prompt)
+        self.assertIn("valid_must_fix", prompt)
+        self.assertIn("mark_pr_open", prompt)
+
+    def test_prompts_use_exact_mark_pr_open_rearm_command(self):
+        run = _run()
+        c = self._inline(body="ref.read after await should be guarded")
+        reality = _reality(review_comments=(c,))
+        expected = mark_pr_open_command(
+            run.repository_full_name, run.github_issue_number, reality.pr_number,
+        )
+        for prompt in (
+            build_validation_handoff_prompt(run, reality, [c.stable_key]),
+            build_fix_prompt(run, reality),
+        ):
+            with self.subTest(prompt=prompt.splitlines()[0]):
+                self.assertIn(expected, prompt)
+                self.assertIn("PYTHONPATH=", prompt)
+                self.assertIn(sys.executable, prompt)
+                self.assertIn("-m u_agents.mark_pr_open", prompt)
+                self.assertNotIn("`python -m u_agents.mark_pr_open`", prompt)
+
+
+class TestPhraseSafeMarkers(unittest.TestCase):
+    """Finding 2: forward-looking 'must be addressed' / 'should be resolved'
+    phrasings must not be silently classified invalid/optional from a bare
+    'addressed'/'resolved' substring."""
+
+    def _c(self, body):
+        return ReviewComment(comment_id="1", body=body, source="inline")
+
+    def test_forward_looking_phrases_escalate_not_invalidated(self):
+        for body in (
+            "This must be addressed before merge",
+            "This blocking bug should be resolved",
+            "blocking bug should be resolved",
+        ):
+            with self.subTest(body=body):
+                verdict = default_validate_comment(self._c(body))
+                self.assertEqual(verdict, "needs_user_judgment")
+                self.assertNotIn(verdict, ("invalid", "valid_optional"))
+
+    def test_past_dismissive_phrases_are_invalid(self):
+        for body in (
+            "already addressed",
+            "has been addressed",
+            "resolved already",
+            "this was resolved in a prior commit",
+            "outdated",
+            "wontfix",
+        ):
+            with self.subTest(body=body):
+                self.assertEqual(default_validate_comment(self._c(body)), "invalid")
+
+    def test_must_fix_signal_survives_forward_resolved_phrasing(self):
+        from u_agents.pr_watcher import _body_has_must_fix_signal
+
+        # A blocking comment that says it "should be resolved" is still a
+        # must-fix signal; a dismissive "already resolved" is not.
+        self.assertTrue(_body_has_must_fix_signal("blocking bug should be resolved"))
+        self.assertFalse(
+            _body_has_must_fix_signal("this is blocking but already addressed")
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_env_setup.py
+++ b/tests/test_runtime_env_setup.py
@@ -1,0 +1,84 @@
+import re
+import unittest
+from pathlib import Path
+
+from u_agents.contract import ConfigError
+from u_agents.control_plane import (
+    ENV_DATABASE_URL,
+    ENV_MACHINE_ID,
+    ENV_RUNNER_ID,
+    database_url_from_env,
+    load_runner_identity,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ENV_TEMPLATE = REPO_ROOT / ".u_agents_env.zsh.template"
+ZSHRC = REPO_ROOT / ".zshrc"
+DOCS = REPO_ROOT / "docs" / "u-agents.md"
+
+# Same forbidden personal markers guarded for the launchd examples.
+PERSONAL_PATTERNS = [
+    re.compile(r"/Users/yutaaoki(?:/|$)"),
+    re.compile(r"\byutaaoki\b"),
+    re.compile(r"\buuta\b"),
+]
+
+
+def _exports(text: str) -> dict:
+    out = {}
+    for m in re.finditer(r'^\s*export\s+([A-Z_]+)="?([^"\n]*)"?\s*$', text, re.M):
+        out[m.group(1)] = m.group(2)
+    return out
+
+
+class TestEnvTemplate(unittest.TestCase):
+    def setUp(self):
+        self.assertTrue(ENV_TEMPLATE.exists(), f"missing {ENV_TEMPLATE}")
+        self.text = ENV_TEMPLATE.read_text(encoding="utf-8")
+        self.exports = _exports(self.text)
+
+    def test_template_exports_all_required_vars(self):
+        for key in (ENV_DATABASE_URL, ENV_RUNNER_ID, ENV_MACHINE_ID):
+            self.assertIn(key, self.exports, f"template missing export {key}")
+
+    def test_database_url_has_valid_scheme(self):
+        url = self.exports[ENV_DATABASE_URL]
+        self.assertEqual(database_url_from_env({ENV_DATABASE_URL: url}), url)
+
+    def test_identity_placeholders_fail_loudly_until_edited(self):
+        with self.assertRaises(ConfigError):
+            load_runner_identity({
+                ENV_RUNNER_ID: self.exports[ENV_RUNNER_ID],
+                ENV_MACHINE_ID: self.exports[ENV_MACHINE_ID],
+            })
+
+    def test_template_has_no_personal_values(self):
+        for pat in PERSONAL_PATTERNS:
+            self.assertIsNone(
+                pat.search(self.text),
+                f"template contains forbidden pattern {pat.pattern!r}",
+            )
+
+    def test_template_instructs_private_file_mode(self):
+        self.assertIn("chmod 600 ~/.u_agents_env.zsh", self.text)
+
+
+class TestZshrcSourcesEnv(unittest.TestCase):
+    def test_zshrc_guards_and_sources_local_env_file(self):
+        text = ZSHRC.read_text(encoding="utf-8")
+        # Guarded source so shells without the local file are unaffected, and
+        # the real file lives outside the repo (in $HOME), never tracked.
+        self.assertRegex(
+            text,
+            r'\[\[ -f "\$HOME/\.u_agents_env\.zsh" \]\] && source "\$HOME/\.u_agents_env\.zsh"',
+        )
+
+
+class TestRuntimeEnvDocs(unittest.TestCase):
+    def test_docs_instruct_private_file_mode(self):
+        text = DOCS.read_text(encoding="utf-8")
+        self.assertIn("chmod 600 ~/.u_agents_env.zsh", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/u_agents/README.md
+++ b/u_agents/README.md
@@ -11,6 +11,7 @@ Layout:
 - `launcher.py` — short-lived starter/resumer (`python3 -m u_agents.launcher`).
 - `watchdog.py` — stall detector (`python3 -m u_agents.watchdog`).
 - `pr_watcher.py` — DB-backed PR phase watcher (`python3 -m u_agents.pr_watcher`).
+- `mark_pr_open.py` — PM-run CLI to record an opened PR (`phase=pr_open`, `pr_number`).
 - `prompts/pm.md` — PM prompt template sent into the tmux PM pane.
 - `compose.yml` — local PostgreSQL 17 for v0.2 control-plane development.
 - `db/` — `agent_runs` schema and contract docs.

--- a/u_agents/agent_runs.py
+++ b/u_agents/agent_runs.py
@@ -362,6 +362,32 @@ class AgentRunsClient:
             "metadata": json.dumps(dict(metadata or {})),
         })
 
+    def mark_pr_open(
+        self,
+        repository_full_name: str,
+        github_issue_number: int,
+        *,
+        pr_number: int,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> AgentRun:
+        """Durably record that a PR was opened for this run.
+
+        Sets ``phase = 'pr_open'`` and ``pr_number`` so the PR watcher's
+        ``list_pr_watch_runs`` query (phase in pr_open/pr_watching/ready_to_merge
+        AND pr_number IS NOT NULL) picks the run up. This is the persisted
+        hand-off from PM/automation to the PR watcher; it must not rely on PM
+        prompt memory alone.
+        """
+        observation: dict[str, Any] = dict(metadata or {})
+        observation["pr_open"] = {"pr_number": pr_number}
+        return self.update_pr_fields(
+            repository_full_name,
+            github_issue_number,
+            pr_number=pr_number,
+            phase="pr_open",
+            metadata=observation,
+        )
+
     def record_observation(
         self,
         repository_full_name: str,

--- a/u_agents/db/README.md
+++ b/u_agents/db/README.md
@@ -118,21 +118,57 @@ cancelled
 
 ## PR watcher rules
 
-Automated PR review comment fixes are allowed at most once.
+Automated PR review comment fixes are allowed at most once, and only after a
+comment has been validated.
 
 1. If the PR is merged, set `phase = 'done'`.
-2. If there are must-fix PR comments and `pr_review_fix_rounds = 0`, set
-   `phase = 'fixing'`, increment `pr_review_fix_rounds`, and assign the
-   engineer the current must-fix list.
-3. If there are must-fix PR comments and `pr_review_fix_rounds >= 1`, set
-   `phase = 'blocked'` with a `block_reason`.
-4. If CI is green and there are no must-fix review comments, set
+2. If there is a fresh validated must-fix comment and `pr_review_fix_rounds = 0`,
+   set `phase = 'fixing'`, increment `pr_review_fix_rounds`, mark that comment
+   attempted, and assign the engineer the must-fix list.
+3. If a validated must-fix comment was already attempted once but is still
+   present, set `phase = 'blocked'` (it cannot be auto-fixed again and must not
+   be ignored).
+4. If any collected comment is classified `needs_user_judgment`:
+   - in the production `pr_watcher` CLI path, fresh keys are handed to the
+     existing PM pane for validation, marked `handed_off`, and parked in
+     `phase = 'fixing'` until the PM re-arms the watcher with `mark_pr_open`;
+   - with no live dispatcher, or if the same ambiguous key is already
+     `handed_off`, set `phase = 'blocked'` so a human decides (no repeat
+     auto-handoff).
+5. If there is a fresh validated must-fix comment and
+   `pr_review_fix_rounds >= 1`, set `phase = 'blocked'` (global round cap).
+6. If CI is green and there are no actionable/unresolved/judgment comments, set
    `phase = 'ready_to_merge'`.
-5. Otherwise remain in `phase = 'pr_watching'`.
+7. Otherwise remain in `phase = 'pr_watching'`.
 
-Review comment classification must distinguish must-fix items from optional,
-rejected, stale, or already-addressed comments before applying these rules.
+The watcher collects both top-level PR comments / review summaries and inline
+review comments (`/repos/{owner}/{repo}/pulls/{n}/comments`). If the inline
+fetch fails or returns malformed output, the pass is deferred (transient), not
+treated as "no comments". Comments are not always correct, so **every**
+candidate — inline comments, top-level comments with a must-fix or
+forward-action signal, `CHANGES_REQUESTED` review summaries, and a bare
+`reviewDecision = CHANGES_REQUESTED` — passes through the validation gate before
+it can become a must-fix input; none auto-trigger a fix. Verdicts are
+`valid_must_fix`,
+`valid_optional`, `invalid`, and `needs_user_judgment`. Marker text, a
+`CHANGES_REQUESTED` summary, high-priority styling, or bot authorship alone
+never make a comment `valid_must_fix`.
+
+### Per-comment at-most-once bookkeeping
+
+`metadata.pr_review_comments` maps a stable comment identity (GitHub review
+comment id + a body hash) to `{verdict, attempted, handed_off, ...}`, merged
+forward across passes so prior `attempted` / `handed_off` state is never lost
+when a fetch returns fewer/no comments. A `valid_must_fix` comment triggers one
+automated fix attempt and is then marked `attempted`; the same id+hash on later
+passes is not auto-fixed again (and if still present it escalates to `blocked`
+rather than being ignored). A `needs_user_judgment` comment is handed off to the
+PM pane at most once via `handed_off`; after the PM re-arms the watcher with
+`mark_pr_open`, the same still-ambiguous key blocks instead of being re-sent. A
+changed body yields a new key, so an edited comment is treated as a fresh
+validation candidate. This per-comment cap is enforced in addition to the global
+`pr_review_fix_rounds` one-round cap.
 
 The PR watcher never merges a PR. `ready_to_merge` is a notification state for
-the user/operator after GitHub PR existence, head branch, CI, and must-fix
+the user/operator after GitHub PR existence, head branch, CI, and validated
 comment state have been verified.

--- a/u_agents/launcher.py
+++ b/u_agents/launcher.py
@@ -610,6 +610,16 @@ def render_pm_prompt(template_path: Path, issue: Issue, window: str) -> str:
         "tmux_session": TMUX_SESSION,
         "tmux_window": window,
         "pm_pane": pm_pane_target(window),
+        # Dotfiles checkout root that contains the `u_agents/` package. The PM
+        # cd's into the target repo worktree, which does not have u_agents on
+        # the path, so DB helpers must be invoked with this on PYTHONPATH.
+        # Shell-quoted so paths with spaces stay safe.
+        "u_agents_root": shlex.quote(str(PACKAGE_DIR.parent)),
+        # The interpreter running this launcher, which has already imported
+        # psycopg via AgentRunsClient.from_env(). The PM must reuse it instead
+        # of a bare `python3`, which mise/PATH in the target worktree may
+        # resolve to a Python without psycopg. Shell-quoted for safety.
+        "u_agents_python": shlex.quote(sys.executable),
     }
     tmpl = template_path.read_text(encoding="utf-8")
 

--- a/u_agents/mark_pr_open.py
+++ b/u_agents/mark_pr_open.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""CLI to durably record an opened PR in ``agent_runs``.
+
+After the PM (or any automation) opens a PR for an issue, the ``agent_runs``
+row must be advanced to ``phase = 'pr_open'`` with ``pr_number`` set so the PR
+watcher picks it up. The PM runs this from its tmux pane instead of relying on
+prompt memory. PM panes normally run the rendered command from
+``u_agents/prompts/pm.md`` so the package root and psycopg-enabled Python
+interpreter are explicit:
+
+    PYTHONPATH=/path/to/dotfiles /path/to/python -m u_agents.mark_pr_open --repo owner/name --issue 233 --pr 240
+
+Live runs require ``U_AGENTS_DATABASE_URL``, ``U_AGENTS_RUNNER_ID``,
+``U_AGENTS_MACHINE_ID``, ``psycopg``, and reachable Postgres (same runtime as
+the launcher/watchdog). ``--help`` does not import psycopg.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from u_agents.agent_runs import AgentRun, AgentRunsClient
+
+
+def record_pr_open(
+    db_client,
+    repository_full_name: str,
+    github_issue_number: int,
+    pr_number: int,
+) -> AgentRun:
+    """Persist the PR-open transition via the shared client method.
+
+    Kept separate from ``main`` so it can be unit-tested with a fake client
+    without touching ``AgentRunsClient.from_env`` / psycopg.
+    """
+    return db_client.mark_pr_open(
+        repository_full_name,
+        github_issue_number,
+        pr_number=pr_number,
+    )
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(
+        description=(
+            "Record an opened PR in agent_runs (phase=pr_open, pr_number set) "
+            "so the PR watcher can take over."
+        )
+    )
+    p.add_argument("--repo", required=True, help="GitHub repository owner/name")
+    p.add_argument("--issue", required=True, type=int, help="GitHub issue number")
+    p.add_argument("--pr", required=True, type=int, help="opened PR number")
+    args = p.parse_args(argv)
+
+    db_client = AgentRunsClient.from_env()
+    try:
+        run = record_pr_open(db_client, args.repo, args.issue, args.pr)
+    finally:
+        db_client.close()
+    print(
+        f"{run.repository_full_name}#{run.github_issue_number}: "
+        f"phase={run.phase} pr={run.pr_number}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/u_agents/pr_watcher.py
+++ b/u_agents/pr_watcher.py
@@ -3,14 +3,57 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import shlex
 import subprocess
 import sys
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Callable
 
 from u_agents.agent_runs import AgentRun, AgentRunsClient
+from u_agents.contract import pm_pane_target
 from u_agents.control_plane import decide_pr_watch_phase
+
+
+# Verdicts produced by the validation gate. Only ``valid_must_fix`` is eligible
+# for an automated fix attempt, and only once per stable comment identity.
+REVIEW_VERDICTS = (
+    "valid_must_fix",
+    "valid_optional",
+    "invalid",
+    "needs_user_judgment",
+)
+
+
+@dataclass(frozen=True)
+class ReviewComment:
+    """A PR review comment to be triaged before any automated handling.
+
+    ``source`` is ``inline`` (per-file/line review comment), ``comment``
+    (top-level PR comment), or ``latest_review`` (a review summary). The stable
+    key is the GitHub comment id plus a body hash, so a re-posted identical
+    comment maps to the same key while an edited body becomes a new candidate.
+    """
+
+    comment_id: str
+    body: str
+    source: str
+    path: str | None = None
+    line: int | None = None
+    author: str = ""
+    author_type: str = ""
+    state: str = ""
+
+    @property
+    def body_hash(self) -> str:
+        return hashlib.sha256(self.body.encode("utf-8", "replace")).hexdigest()
+
+    @property
+    def stable_key(self) -> str:
+        return f"{self.comment_id}:{self.body_hash[:12]}"
 
 
 @dataclass(frozen=True)
@@ -23,6 +66,7 @@ class PrReality:
     must_fix_review_comments: bool
     closed: bool = False
     must_fix_comment_keys: tuple[str, ...] = ()
+    review_comments: tuple[ReviewComment, ...] = ()
 
 
 def _run(cmd: list[str]) -> subprocess.CompletedProcess:
@@ -66,17 +110,37 @@ _MUST_FIX_MARKERS = (
     "blocking",
     "blocker",
 )
+
+# Phrase-anchored "this was already dealt with / does not apply" markers. These
+# must NOT contain the bare words "addressed" or "resolved": a bare substring
+# match silently swallows forward-looking, actionable comments such as
+# "this must be addressed before merge" or "blocking bug should be resolved".
+# Only past/dismissive phrasings count as dismissive.
+_DISMISSIVE_MARKERS = (
+    "already addressed",
+    "addressed already",
+    "has been addressed",
+    "have been addressed",
+    "was addressed",
+    "were addressed",
+    "already resolved",
+    "resolved already",
+    "has been resolved",
+    "have been resolved",
+    "was resolved",
+    "were resolved",
+    "outdated",
+    "wontfix",
+    "won't fix",
+    "stale",
+    "rejected",
+)
 _NON_MUST_FIX_MARKERS = (
     "optional",
     "non-blocking",
     "nonblocking",
     "nit:",
-    "already addressed",
-    "addressed",
-    "resolved",
-    "stale",
-    "rejected",
-)
+) + _DISMISSIVE_MARKERS
 
 
 def _comment_body(item) -> str:
@@ -97,6 +161,23 @@ def _body_has_must_fix_signal(body: str) -> bool:
     if not any(marker in normalized for marker in _MUST_FIX_MARKERS):
         return False
     return not any(marker in normalized for marker in _NON_MUST_FIX_MARKERS)
+
+
+def _body_is_validation_candidate(body: str) -> bool:
+    """Whether a top-level comment/review body should be routed to validation.
+
+    Broader than ``_body_has_must_fix_signal``: it also catches forward-looking,
+    actionable phrasings ("this must be addressed before merge", "blocking bug
+    should be resolved") so they become ``ReviewComment`` objects and reach the
+    validation gate instead of being silently ignored on the way to
+    ready_to_merge. Dismissive/optional bodies are still suppressed.
+    """
+    normalized = body.lower().replace("_", "-")
+    if any(marker in normalized for marker in _NON_MUST_FIX_MARKERS):
+        return False
+    if any(marker in normalized for marker in _MUST_FIX_MARKERS):
+        return True
+    return any(marker in normalized for marker in _FORWARD_ACTION_MARKERS)
 
 
 def extract_must_fix_review_comment_keys(pr_data: dict) -> tuple[str, ...]:
@@ -124,15 +205,322 @@ def extract_must_fix_review_comment_keys(pr_data: dict) -> tuple[str, ...]:
                 continue
             state = str(item.get("state") or "").upper()
             body = _comment_body(item)
-            if state == "CHANGES_REQUESTED" or _body_has_must_fix_signal(body):
+            if state == "CHANGES_REQUESTED" or _body_is_validation_candidate(body):
                 keys.append(_comment_key(prefix, item, index))
     return tuple(keys)
+
+
+# ---------------------------------------------------------------------------
+# Validation gate + triage for PR review comments
+# ---------------------------------------------------------------------------
+
+# Reuse the phrase-anchored dismissive set so "this must be addressed before
+# merge" / "blocking bug should be resolved" are never classified invalid from a
+# bare "addressed"/"resolved" substring.
+_INVALID_MARKERS = _DISMISSIVE_MARKERS
+_OPTIONAL_MARKERS = ("optional", "non-blocking", "nonblocking", "nit:", "nit ")
+
+# Forward-looking, actionable phrasings that are NOT must-fix markers on their
+# own (no "blocking"/"must fix" token) but clearly demand a change. Under the
+# conservative default these escalate to needs_user_judgment instead of being
+# silently treated as optional.
+_FORWARD_ACTION_MARKERS = (
+    "must be addressed",
+    "should be addressed",
+    "needs to be addressed",
+    "must be resolved",
+    "should be resolved",
+    "needs to be resolved",
+    "must be fixed",
+    "should be fixed",
+    "needs to be fixed",
+    "before merge",
+    "before merging",
+)
+
+
+def default_validate_comment(comment: ReviewComment) -> str:
+    """Conservative runtime classification of a single review comment.
+
+    This never returns ``valid_must_fix``: comments are not always correct, so
+    the runtime watcher must not auto-fix based on marker text, a
+    ``CHANGES_REQUESTED`` review summary, high-priority styling, or bot
+    authorship alone. A real ``valid_must_fix`` verdict comes from an explicit
+    validator (an agent) injected by the caller. Anything that looks actionable
+    but cannot be confirmed here is escalated as ``needs_user_judgment``.
+    """
+    state = (comment.state or "").upper()
+    if state == "CHANGES_REQUESTED":
+        # A CHANGES_REQUESTED review summary / reviewDecision is not a concrete
+        # validated change; surface the decision rather than auto-fixing.
+        return "needs_user_judgment"
+    body = (comment.body or "").strip()
+    if not body:
+        # Nothing actionable (e.g. an APPROVED review with no body).
+        return "valid_optional"
+    normalized = body.lower().replace("_", "-")
+    if any(marker in normalized for marker in _INVALID_MARKERS):
+        return "invalid"
+    if any(marker in normalized for marker in _OPTIONAL_MARKERS):
+        return "valid_optional"
+    if (comment.author_type or "").lower() == "bot":
+        # Bot review comments (e.g. gemini-code-assist high-priority notes) are
+        # surfaced for human/agent validation, never auto-fixed from styling.
+        return "needs_user_judgment"
+    if _body_has_must_fix_signal(comment.body) or any(
+        marker in normalized for marker in _FORWARD_ACTION_MARKERS
+    ):
+        # Actionable but unconfirmed (e.g. "this must be addressed before
+        # merge"): escalate rather than silently downgrading to optional.
+        return "needs_user_judgment"
+    return "valid_optional"
+
+
+@dataclass(frozen=True)
+class CommentTriage:
+    bookkeeping: dict
+    actionable_keys: list
+    needs_judgment_keys: list
+    # valid_must_fix comments still present this pass that were already attempted
+    # once: not auto-fixed again, but not silently ignored either.
+    unresolved_keys: list = field(default_factory=list)
+    invalid_keys: list = field(default_factory=list)
+    optional_keys: list = field(default_factory=list)
+
+
+def triage_review_comments(
+    comments,
+    prior_bookkeeping,
+    validate: Callable[[ReviewComment], str] = default_validate_comment,
+) -> CommentTriage:
+    """Run review comments through the validation gate with at-most-once memory.
+
+    ``prior_bookkeeping`` is the persisted per-comment state keyed by
+    ``ReviewComment.stable_key`` (id + body hash). A ``valid_must_fix`` comment
+    is only ``actionable`` if it has not already been attempted under the same
+    key; if it was attempted and is still present it is reported as
+    ``unresolved`` instead (do not auto-fix again, but do not ignore it). An
+    edited body produces a new key, so it is treated as a fresh candidate.
+
+    Prior bookkeeping is merged forward, not replaced: a pass that sees an
+    empty or partial comment list must not drop previously recorded
+    verdict/attempted state, or the at-most-once guarantee would weaken.
+    """
+    if not isinstance(prior_bookkeeping, Mapping):
+        prior_bookkeeping = {}
+    # Start from prior state so historical (esp. attempted) keys survive even
+    # when the current fetch returns fewer/no comments.
+    bookkeeping: dict = {
+        k: dict(v) for k, v in prior_bookkeeping.items() if isinstance(v, Mapping)
+    }
+    actionable: list = []
+    needs_judgment: list = []
+    unresolved: list = []
+    invalid_keys: list = []
+    optional_keys: list = []
+    for comment in comments:
+        key = comment.stable_key
+        verdict = validate(comment)
+        if verdict not in REVIEW_VERDICTS:
+            verdict = "needs_user_judgment"
+        prior = prior_bookkeeping.get(key)
+        attempted = bool(prior.get("attempted")) if isinstance(prior, Mapping) else False
+        handed_off = bool(prior.get("handed_off")) if isinstance(prior, Mapping) else False
+        bookkeeping[key] = {
+            "verdict": verdict,
+            "attempted": attempted,
+            "handed_off": handed_off,
+            "comment_id": comment.comment_id,
+            "body_hash": comment.body_hash[:12],
+            "source": comment.source,
+            "path": comment.path,
+            "line": comment.line,
+        }
+        if verdict == "valid_must_fix":
+            if attempted:
+                unresolved.append(key)
+            else:
+                actionable.append(key)
+        elif verdict == "needs_user_judgment":
+            needs_judgment.append(key)
+        elif verdict == "invalid":
+            invalid_keys.append(key)
+        elif verdict == "valid_optional":
+            optional_keys.append(key)
+    return CommentTriage(
+        bookkeeping=bookkeeping,
+        actionable_keys=actionable,
+        needs_judgment_keys=needs_judgment,
+        unresolved_keys=unresolved,
+        invalid_keys=invalid_keys,
+        optional_keys=optional_keys,
+    )
 
 
 # "could not resolve to" matches GitHub GraphQL missing-resource errors
 # (e.g. "Could not resolve to a PullRequest ..."). It deliberately excludes
 # transient DNS/network failures like "Could not resolve host: api.github.com".
 _PR_ABSENCE_MARKERS = ("not found", "could not resolve to", "404")
+
+# Fields requested from `gh pr view --json`. The current gh CLI does NOT expose
+# a `merged` boolean field; requesting it fails with `Unknown JSON field:
+# "merged"` (exit 1), which the absence markers above do not match, so the
+# watcher would defer the run forever and never progress. Merged/closed/open
+# state is instead inferred from the supported `state` (OPEN/CLOSED/MERGED) and
+# `mergedAt` fields. Keep this list to fields gh actually supports.
+PR_VIEW_JSON_FIELDS = (
+    "number",
+    "headRefName",
+    "state",
+    "mergedAt",
+    "statusCheckRollup",
+    "reviewDecision",
+    "comments",
+    "latestReviews",
+)
+
+
+def _author_login_type(item: dict) -> tuple[str, str]:
+    """Return (login, type) from a GitHub comment/review item.
+
+    Inline review comments expose ``user``; ``gh pr view`` comments/reviews
+    expose ``author``. Bot accounts are reported as type ``Bot`` by the REST
+    API, but the GraphQL author shape may omit it, so fall back to the
+    ``[bot]`` login suffix.
+    """
+    author = item.get("user")
+    if not isinstance(author, dict):
+        author = item.get("author")
+    if not isinstance(author, dict):
+        author = {}
+    login = str(author.get("login") or "")
+    atype = str(author.get("type") or "")
+    if not atype and login.endswith("[bot]"):
+        atype = "Bot"
+    return login, atype
+
+
+def fetch_review_comments(repository_full_name: str, pr_number: int) -> tuple[ReviewComment, ...]:
+    """Fetch inline PR review comments (per-file/line) via the REST API.
+
+    ``gh pr view`` only exposes top-level PR comments and review summaries, not
+    the inline review comments attached to specific diff lines. Those live at
+    ``/repos/{owner}/{repo}/pulls/{n}/comments``.
+
+    A failed call or malformed/non-list output is ambiguous (it is not proof
+    the PR has no inline comments), so this raises ``RuntimeError``. The PR
+    already exists at this point (``gh pr view`` succeeded), so the caller
+    treats the failure as transient and defers the run instead of mutating DB
+    state as if there were nothing to validate.
+    """
+    res = _run([
+        "gh", "api",
+        f"repos/{repository_full_name}/pulls/{pr_number}/comments?per_page=100",
+    ])
+    if res.returncode != 0:
+        raise RuntimeError(
+            f"gh api inline review comments failed for "
+            f"{repository_full_name}#{pr_number} (exit {res.returncode}); "
+            f"treating as transient: {(res.stderr or '').strip()}"
+        )
+    try:
+        data = json.loads(res.stdout or "[]")
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"gh api returned unparseable inline review comments for "
+            f"{repository_full_name}#{pr_number}: {e}"
+        ) from e
+    if not isinstance(data, list):
+        raise RuntimeError(
+            f"gh api returned non-list inline review comments for "
+            f"{repository_full_name}#{pr_number}: {type(data).__name__}"
+        )
+    out: list[ReviewComment] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        cid = item.get("id")
+        if cid is None:
+            continue
+        login, atype = _author_login_type(item)
+        line = item.get("line")
+        if line is None:
+            line = item.get("original_line")
+        out.append(ReviewComment(
+            comment_id=str(cid),
+            body=str(item.get("body") or ""),
+            source="inline",
+            path=item.get("path"),
+            line=line,
+            author=login,
+            author_type=atype,
+        ))
+    return tuple(out)
+
+
+def _top_level_review_comments(data: dict) -> tuple[ReviewComment, ...]:
+    """Represent must-fix-looking top-level comments / review summaries as
+    ``ReviewComment`` objects so they pass through the same validation gate as
+    inline comments instead of auto-triggering a fix.
+
+    Items selected for validation are those a validation candidate predicate
+    flags: top-level comments with a must-fix or forward-action signal,
+    ``CHANGES_REQUESTED`` review summaries, and review summaries with such a
+    signal. Forward-looking phrasings ("must be addressed before merge") count
+    as candidates so they are not dropped before validation. A bare
+    ``reviewDecision == CHANGES_REQUESTED`` (with no concrete comment) becomes a
+    sentinel so it escalates to user judgment rather than auto-fixing.
+    """
+    out: list[ReviewComment] = []
+    saw_changes_requested = False
+
+    comments = data.get("comments")
+    if isinstance(comments, list):
+        for index, item in enumerate(comments):
+            if not isinstance(item, dict):
+                continue
+            body = _comment_body(item)
+            if not _body_is_validation_candidate(body):
+                continue
+            login, atype = _author_login_type(item)
+            out.append(ReviewComment(
+                comment_id=_comment_key("comment", item, index),
+                body=body,
+                source="comment",
+                author=login,
+                author_type=atype,
+            ))
+
+    reviews = data.get("latestReviews")
+    if isinstance(reviews, list):
+        for index, item in enumerate(reviews):
+            if not isinstance(item, dict):
+                continue
+            state = str(item.get("state") or "").upper()
+            body = _comment_body(item)
+            if state != "CHANGES_REQUESTED" and not _body_is_validation_candidate(body):
+                continue
+            if state == "CHANGES_REQUESTED":
+                saw_changes_requested = True
+            login, atype = _author_login_type(item)
+            out.append(ReviewComment(
+                comment_id=_comment_key("latest_review", item, index),
+                body=body,
+                source="latest_review",
+                author=login,
+                author_type=atype,
+                state=state,
+            ))
+
+    if not saw_changes_requested and data.get("reviewDecision") == "CHANGES_REQUESTED":
+        out.append(ReviewComment(
+            comment_id="reviewDecision:CHANGES_REQUESTED",
+            body="",
+            source="review_decision",
+            state="CHANGES_REQUESTED",
+        ))
+
+    return tuple(out)
 
 
 def _missing_pr_reality(pr_number: int) -> PrReality:
@@ -150,11 +538,7 @@ def fetch_pr_reality(repository_full_name: str, pr_number: int) -> PrReality:
     res = _run([
         "gh", "pr", "view", str(pr_number),
         "--repo", repository_full_name,
-        "--json",
-        (
-            "number,headRefName,state,merged,statusCheckRollup,reviewDecision,"
-            "comments,latestReviews"
-        ),
+        "--json", ",".join(PR_VIEW_JSON_FIELDS),
     ])
     if res.returncode != 0:
         stderr = (res.stderr or "").lower()
@@ -175,19 +559,29 @@ def fetch_pr_reality(repository_full_name: str, pr_number: int) -> PrReality:
             f"gh pr view returned unparseable JSON for "
             f"{repository_full_name}#{pr_number}: {e}"
         ) from e
-    state = data.get("state")
+    state = str(data.get("state") or "").upper()
+    # gh reports a merged PR as state == "MERGED" and also stamps mergedAt;
+    # either signal counts as merged. A non-merged terminal PR is "CLOSED".
+    merged = state == "MERGED" or bool(data.get("mergedAt"))
+    closed = state == "CLOSED"
     must_fix_comment_keys = extract_must_fix_review_comment_keys(data)
     if not must_fix_comment_keys and data.get("reviewDecision") == "CHANGES_REQUESTED":
         must_fix_comment_keys = ("reviewDecision:CHANGES_REQUESTED",)
+    # All candidate comments (top-level + reviews + inline) flow through the
+    # validation gate; none of them auto-trigger a fix on their own.
+    review_comments = _top_level_review_comments(data) + fetch_review_comments(
+        repository_full_name, pr_number,
+    )
     return PrReality(
         exists=True,
         pr_number=int(data["number"]),
         head_branch=str(data.get("headRefName") or ""),
-        merged=bool(data.get("merged")),
-        closed=state == "CLOSED",
+        merged=merged,
+        closed=closed,
         ci_green=_status_checks_green(data.get("statusCheckRollup")),
         must_fix_review_comments=bool(must_fix_comment_keys),
         must_fix_comment_keys=must_fix_comment_keys,
+        review_comments=review_comments,
     )
 
 
@@ -197,6 +591,8 @@ def reconcile_pr_run(
     db_client,
     *,
     assign_fix: Callable[[AgentRun, PrReality], None] | None = None,
+    dispatch_handoff: Callable[[AgentRun, PrReality, list], bool] | None = None,
+    validate_comment: Callable[[ReviewComment], str] = default_validate_comment,
 ) -> AgentRun:
     if run.pr_number is None:
         return db_client.mark_blocked(
@@ -235,12 +631,32 @@ def reconcile_pr_run(
             metadata={"pr_watcher": {"verified": True, "closed": True}},
         )
 
+    prior_bookkeeping = {}
+    if isinstance(run.metadata, Mapping):
+        prior_bookkeeping = run.metadata.get("pr_review_comments") or {}
+    triage = triage_review_comments(
+        reality.review_comments, prior_bookkeeping, validate_comment,
+    )
+
+    # Only validated must-fix comments that have not yet been auto-fixed are
+    # eligible to trigger a fix. The legacy reality.must_fix_review_comments
+    # signal no longer drives fixing directly: those raw comments are routed
+    # through the validation gate as ReviewComment objects instead.
+    must_fix = bool(triage.actionable_keys)
     decision = decide_pr_watch_phase(
         pr_merged=reality.merged,
         ci_green=reality.ci_green,
-        must_fix_review_comments=reality.must_fix_review_comments,
+        must_fix_review_comments=must_fix,
         pr_review_fix_rounds=run.pr_review_fix_rounds,
     )
+
+    # Mark the fresh actionable comments as attempted only when this pass is
+    # actually going to assign a fix round, so each comment id+hash is auto-
+    # fixed at most once across passes.
+    if decision.increment_fix_rounds:
+        for key in triage.actionable_keys:
+            triage.bookkeeping[key]["attempted"] = True
+
     metadata = {
         "pr_watcher": {
             "verified": True,
@@ -252,14 +668,114 @@ def reconcile_pr_run(
             "must_fix_comment_keys": list(reality.must_fix_comment_keys[:20]),
             "merged": reality.merged,
             "closed": reality.closed,
+            "review_comment_triage": {
+                "actionable": list(triage.actionable_keys),
+                "unresolved": list(triage.unresolved_keys),
+                "needs_user_judgment": list(triage.needs_judgment_keys),
+                "invalid": list(triage.invalid_keys),
+                "valid_optional": list(triage.optional_keys),
+                "handed_off": [
+                    k for k in triage.needs_judgment_keys
+                    if triage.bookkeeping.get(k, {}).get("handed_off")
+                ],
+            },
         },
+        "pr_review_comments": triage.bookkeeping,
     }
+
+    # Merged wins over everything else.
     if decision.phase == "done":
         return db_client.mark_done(
             run.repository_full_name,
             run.github_issue_number,
             metadata=metadata,
         )
+
+    # A fresh validated must-fix with budget left: assign exactly one fix round.
+    if decision.phase == "fixing":
+        updated = db_client.update_pr_fields(
+            run.repository_full_name,
+            run.github_issue_number,
+            pr_number=reality.pr_number,
+            phase=decision.phase,
+            increment_fix_rounds=decision.increment_fix_rounds,
+            metadata=metadata,
+        )
+        if assign_fix is not None:
+            assign_fix(updated, reality)
+        return updated
+
+    # Not fixing this pass. A validated must-fix that was already attempted but
+    # is still present must NOT slip through to ready_to_merge: it cannot be
+    # auto-fixed again, so escalate to a human.
+    if triage.unresolved_keys:
+        reason = (
+            "valid must-fix PR review comments remain after the automated fix "
+            "attempt: " + ", ".join(triage.unresolved_keys[:20])
+        )
+        return db_client.mark_blocked(
+            run.repository_full_name,
+            run.github_issue_number,
+            reason,
+            metadata=metadata,
+        )
+
+    # Comments needing a human/agent decision. With a live ``dispatch_handoff``
+    # the watcher hands the *fresh* (not-yet-dispatched) keys to the existing PM
+    # pane for validation+fix instead of dead-ending. Keys already handed off
+    # but still ambiguous escalate to a human rather than being re-sent every
+    # tick. Without a dispatcher (the conservative default / unit tests) this
+    # still blocks for user judgment.
+    if triage.needs_judgment_keys:
+        fresh = [
+            k for k in triage.needs_judgment_keys
+            if not triage.bookkeeping.get(k, {}).get("handed_off")
+        ]
+        if fresh and dispatch_handoff is not None:
+            # Deliver the validation prompt first; only persist the handoff if
+            # delivery succeeded so a transient tmux failure is retried next
+            # tick rather than silently consuming the one-shot handoff.
+            delivered = dispatch_handoff(run, reality, fresh)
+            if delivered:
+                for key in fresh:
+                    triage.bookkeeping[key]["handed_off"] = True
+                metadata["pr_watcher"]["review_comment_triage"]["handed_off"] = [
+                    k for k in triage.needs_judgment_keys
+                    if triage.bookkeeping.get(k, {}).get("handed_off")
+                ]
+                # Park the run out of the watch set while the PM validates/fixes.
+                # The handoff prompt instructs the PM to re-arm via mark_pr_open
+                # (phase -> pr_open) when done, so the watcher re-checks; if the
+                # same keys are still ambiguous then, they will have handed_off
+                # set and escalate below instead of looping.
+                return db_client.update_pr_fields(
+                    run.repository_full_name,
+                    run.github_issue_number,
+                    pr_number=reality.pr_number,
+                    phase="fixing",
+                    metadata=metadata,
+                )
+            # Delivery failed: keep watching and retry next pass (handed_off
+            # stays unset for these keys).
+            return db_client.update_pr_fields(
+                run.repository_full_name,
+                run.github_issue_number,
+                pr_number=reality.pr_number,
+                phase="pr_watching",
+                metadata=metadata,
+            )
+        reason = (
+            "PR review comments need user judgment before automated handling: "
+            + ", ".join(triage.needs_judgment_keys[:20])
+        )
+        return db_client.mark_blocked(
+            run.repository_full_name,
+            run.github_issue_number,
+            reason,
+            metadata=metadata,
+        )
+
+    # Round-cap block (fresh actionable must-fix but no budget left).
     if decision.phase == "blocked":
         return db_client.mark_blocked(
             run.repository_full_name,
@@ -267,7 +783,7 @@ def reconcile_pr_run(
             decision.block_reason,
             metadata=metadata,
         )
-    updated = db_client.update_pr_fields(
+    return db_client.update_pr_fields(
         run.repository_full_name,
         run.github_issue_number,
         pr_number=reality.pr_number,
@@ -275,9 +791,6 @@ def reconcile_pr_run(
         increment_fix_rounds=decision.increment_fix_rounds,
         metadata=metadata,
     )
-    if decision.increment_fix_rounds and assign_fix is not None:
-        assign_fix(updated, reality)
-    return updated
 
 
 def check_once(
@@ -285,6 +798,8 @@ def check_once(
     *,
     fetch_reality: Callable[[str, int], PrReality] = fetch_pr_reality,
     assign_fix: Callable[[AgentRun, PrReality], None] | None = None,
+    dispatch_handoff: Callable[[AgentRun, PrReality, list], bool] | None = None,
+    validate_comment: Callable[[ReviewComment], str] = default_validate_comment,
 ) -> list[AgentRun]:
     updated: list[AgentRun] = []
     for run in db_client.list_pr_watch_runs():
@@ -294,6 +809,8 @@ def check_once(
                 PrReality(False, 0, "", False, False, False),
                 db_client,
                 assign_fix=assign_fix,
+                dispatch_handoff=dispatch_handoff,
+                validate_comment=validate_comment,
             ))
             continue
         try:
@@ -312,8 +829,173 @@ def check_once(
             reality,
             db_client,
             assign_fix=assign_fix,
+            dispatch_handoff=dispatch_handoff,
+            validate_comment=validate_comment,
         ))
     return updated
+
+
+# ---------------------------------------------------------------------------
+# Live (production) handoff to the existing PM tmux pane
+# ---------------------------------------------------------------------------
+#
+# The watcher does not own its own agent. When a review comment cannot be
+# auto-classified (the conservative default escalates everything actionable to
+# ``needs_user_judgment``), the live watcher hands the comment(s) to the PM pane
+# that already owns the run (``run.pm_pane`` / ``pm_pane_target(run.tmux_window)``)
+# using the same tmux delivery primitive the launcher uses to seed the PM.
+#
+# Duplicate handoffs are prevented by the per-comment ``handed_off`` flag in
+# ``pr_review_comments`` bookkeeping: only keys without it are dispatched, and a
+# successful delivery parks the run in ``phase='fixing'`` so it leaves the watch
+# set until the PM re-arms it via ``mark_pr_open`` (phase -> ``pr_open``). The
+# same key, if still ambiguous on re-entry, escalates to a human instead of
+# being re-sent.
+
+
+# Directory containing the ``u_agents`` package (the dotfiles checkout root is
+# its parent). Used to build the exact mark_pr_open re-arm command for the PM,
+# which runs inside the target repo worktree where ``u_agents`` is not on the
+# path and a bare ``python3`` may lack ``psycopg``.
+_PACKAGE_DIR = Path(__file__).resolve().parent
+
+
+def mark_pr_open_command(repository_full_name: str, issue_number: int, pr_number: int) -> str:
+    """Exact, shell-quoted re-arm command mirroring the PM prompt contract.
+
+    Uses ``PYTHONPATH=<dotfiles root>`` and the running interpreter
+    (``sys.executable``, which already imported psycopg) instead of a bare
+    ``python -m u_agents.mark_pr_open``.
+    """
+    root = shlex.quote(str(_PACKAGE_DIR.parent))
+    python = shlex.quote(sys.executable)
+    return (
+        f"PYTHONPATH={root} {python} -m u_agents.mark_pr_open "
+        f"--repo {repository_full_name} --issue {issue_number} --pr {pr_number}"
+    )
+
+
+def _comments_by_key(reality: PrReality) -> dict:
+    return {c.stable_key: c for c in reality.review_comments}
+
+
+def _format_comment_lines(reality: PrReality, keys: list) -> str:
+    by_key = _comments_by_key(reality)
+    lines: list[str] = []
+    for key in keys:
+        c = by_key.get(key)
+        if c is None:
+            lines.append(f"- [{key}] (comment no longer present in latest fetch)")
+            continue
+        loc = ""
+        if c.path:
+            loc = f" {c.path}" + (f":{c.line}" if c.line is not None else "")
+        body = " ".join((c.body or "").split())
+        if len(body) > 400:
+            body = body[:400] + "…"
+        lines.append(f"- [{key}]{loc} ({c.source}) {body}")
+    return "\n".join(lines)
+
+
+def build_validation_handoff_prompt(
+    run: AgentRun, reality: PrReality, keys: list
+) -> str:
+    """Prompt that asks the existing PM to validate review comments first.
+
+    Each comment is referenced by its stable ``id:body-hash`` key so the PM can
+    record a verdict per key and address each at most once.
+    """
+    listing = _format_comment_lines(reality, keys)
+    rearm = mark_pr_open_command(
+        run.repository_full_name, run.github_issue_number, reality.pr_number,
+    )
+    return (
+        "u-agents PR watcher handoff: validate PR review comments for "
+        f"{run.repository_full_name}#{run.github_issue_number} "
+        f"(PR #{reality.pr_number}).\n\n"
+        "These review comments are NOT pre-approved. Validate each before "
+        "changing any code:\n\n"
+        f"{listing}\n\n"
+        "Rules:\n"
+        "1. Validate each listed comment first; a comment is not automatically "
+        "correct.\n"
+        "2. Classify each as valid_must_fix, valid_optional, invalid, or "
+        "needs_user_judgment.\n"
+        "3. Do NOT change code for invalid or optional comments.\n"
+        "4. Address only valid_must_fix comments. Address each comment (by its "
+        "[id:hash] key above) at most once; if you already addressed that exact "
+        "key in a previous round, do not redo it.\n"
+        "5. Record your verdict for each key in your PR/issue report "
+        "(key -> verdict + one-line reason).\n"
+        "6. After addressing valid_must_fix comments and pushing, re-arm the "
+        "watcher by running exactly this full command; do not replace it with "
+        "a bare interpreter invocation:\n"
+        f"       {rearm}\n"
+        "7. If a comment is genuinely ambiguous, leave it as "
+        "needs_user_judgment and comment on the issue asking the user; do not "
+        "guess.\n"
+    )
+
+
+def build_fix_prompt(run: AgentRun, reality: PrReality) -> str:
+    """Prompt for the valid_must_fix path (used when an explicit validator has
+    already confirmed must-fix comments). Lists all current review comments and
+    asks the PM to address the validated must-fix ones and re-arm the watcher.
+    """
+    keys = [c.stable_key for c in reality.review_comments]
+    listing = _format_comment_lines(reality, keys)
+    rearm = mark_pr_open_command(
+        run.repository_full_name, run.github_issue_number, reality.pr_number,
+    )
+    return (
+        "u-agents PR watcher: address validated must-fix review comments for "
+        f"{run.repository_full_name}#{run.github_issue_number} "
+        f"(PR #{reality.pr_number}).\n\n"
+        f"{listing}\n\n"
+        "Address each validated must-fix comment exactly once, push, then "
+        "re-arm the watcher by running exactly this full command; do not "
+        "replace it with a bare interpreter invocation:\n"
+        f"       {rearm}\n"
+    )
+
+
+def _send_pm_prompt(run: AgentRun, prompt: str) -> bool:
+    """Deliver ``prompt`` to the run's existing PM pane via tmux.
+
+    Reuses the launcher's tmux delivery (readiness check + buffer paste) so the
+    watcher does not reimplement pane plumbing. Returns True on delivery,
+    False on any tmux/pane failure (logged) so the caller can retry next pass.
+    """
+    from u_agents import launcher
+
+    window = run.tmux_window
+    target = run.pm_pane or pm_pane_target(window)
+    try:
+        launcher.send_prompt(window, prompt, dry_run=False)
+        print(
+            f"u-agents pr-watcher: dispatched prompt to {target} for "
+            f"{run.repository_full_name}#{run.github_issue_number}",
+            file=sys.stderr,
+        )
+        return True
+    except Exception as e:
+        print(
+            f"WARN: could not deliver pr-watcher prompt to {target} for "
+            f"{run.repository_full_name}#{run.github_issue_number}: "
+            f"{type(e).__name__}: {e}",
+            file=sys.stderr,
+        )
+        return False
+
+
+def live_dispatch_handoff(run: AgentRun, reality: PrReality, keys: list) -> bool:
+    """Production handoff: send the validation prompt to the PM pane."""
+    return _send_pm_prompt(run, build_validation_handoff_prompt(run, reality, keys))
+
+
+def live_assign_fix(run: AgentRun, reality: PrReality) -> None:
+    """Production fix dispatch for the valid_must_fix path."""
+    _send_pm_prompt(run, build_fix_prompt(run, reality))
 
 
 def main(argv=None) -> int:
@@ -322,7 +1004,11 @@ def main(argv=None) -> int:
     args = p.parse_args(argv)
     db_client = AgentRunsClient.from_env()
     try:
-        updated = check_once(db_client)
+        updated = check_once(
+            db_client,
+            assign_fix=live_assign_fix,
+            dispatch_handoff=live_dispatch_handoff,
+        )
         for run in updated:
             print(
                 f"{run.repository_full_name}#{run.github_issue_number}: "

--- a/u_agents/prompts/pm.md
+++ b/u_agents/prompts/pm.md
@@ -59,6 +59,12 @@ watchdog recovery path apply. Do not open a PR from pane output alone.
    - If a git worktree already exists at {worktree}, reuse it.
    - Else create it from {main_checkout}: `git -C {main_checkout} worktree add -b {branch} {worktree}` (fall back to checking out an existing remote branch with the same name if present).
    - cd into {worktree} for all subsequent work.
+   - mise trust (only if this repo uses mise): if any of `mise.toml`,
+     `.mise.toml`, or `.config/mise/config.toml` exists in {worktree}, run
+     `mise trust {worktree}` (and `mise install` if tools are declared) before
+     running project commands. An untrusted mise config makes `mise run`/`mise
+     exec` and shell auto-activation fail until trusted. Skip this entirely for
+     repos with no mise config — do not assume every repo uses mise.
 
 2. clarify
    - Read the GitHub issue with `gh issue view {issue_number} --repo {repo_full}`.
@@ -103,6 +109,28 @@ watchdog recovery path apply. Do not open a PR from pane output alone.
    - PR body should reference the issue (`Closes #{issue_number}`) and
      summarize what shipped, how it was verified, and any follow-ups.
    - Do not force push. Do not merge.
+   - Durably record the PR so the PR watcher can take over. This is NOT
+     optional and must not rely on memory: capture the new PR number (from the
+     `gh pr create` URL, or `gh pr view --json number -q .number`) and run
+
+         PYTHONPATH={u_agents_root} {u_agents_python} -m u_agents.mark_pr_open --repo {repo_full} --issue {issue_number} --pr <pr-number>
+
+     Run this command exactly as written — do not substitute a bare `python3`
+     or drop the `PYTHONPATH` prefix. You are inside the target repo worktree
+     ({worktree}), which does not contain the `u_agents` package, and mise/PATH
+     there may select a Python without `psycopg`. `{u_agents_root}` puts the
+     package on the path and `{u_agents_python}` is the exact interpreter the
+     runner already uses (it has `psycopg`); a bare `python3` would fail with
+     `No module named u_agents` or `psycopg` not installed.
+     If this command fails, do not continue as though the PR was recorded:
+     confirm `U_AGENTS_DATABASE_URL`, `U_AGENTS_RUNNER_ID`, and
+     `U_AGENTS_MACHINE_ID` are set in this pane, then retry. If it still
+     fails, comment on the issue with the blocker and stop; the run remains
+     in `pm_started` and the PR watcher will not pick it up until this
+     command succeeds.
+     This advances the `agent_runs` row to `phase=pr_open` with `pr_number`
+     set. The PR watcher only picks up rows in `pr_open`/`pr_watching`/
+     `ready_to_merge` that have a `pr_number`, so skipping this strands the run.
 
 7. report
    - Post a completion summary as a comment on the issue using this format:


### PR DESCRIPTION
## Summary

Fixes the `u_agents` automation workflow so PR tracking can reliably hand off review-comment validation/fixes to agents, records PR-open state durably, and makes runner environment setup reproducible.

## Changes

- Add `u_agents.mark_pr_open` and update the PM prompt so opened PRs are persisted with `phase=pr_open` and `pr_number`.
- Wire PR watcher review-comment triage for inline/top-level comments, validation-before-fix, one-attempt bookkeeping, and PM pane handoff for ambiguous comments.
- Add runner env setup through `.zshrc`, env template, launchd placeholders, and validation around runner/machine identity.
- Update docs and tests for launchd env, PR watcher transitions, PM handoff/re-arm, and review comment edge cases.

## Verification

- `python3 -m unittest tests.test_pr_watcher tests.test_agent_runs tests.test_control_plane` → 109 OK
- `python3 -m unittest discover tests` → 256 OK
- `python3 -m u_agents.pr_watcher --help` → OK
- `git diff --check` → clean
