### PR TITLE
Notify Slack when u_agents opens a PR

### DIFF
--- a/.u_agents_env.zsh.template
+++ b/.u_agents_env.zsh.template
@@ -21,3 +21,10 @@ export U_AGENTS_DATABASE_URL="postgresql://u_agents:u_agents_dev_password@127.0.
 # fails loudly instead of claiming work under a bogus identity.
 export U_AGENTS_RUNNER_ID="runner"
 export U_AGENTS_MACHINE_ID="machine"
+
+# Optional Slack incoming-webhook URL. When set, `mark_pr_open` sends one Slack
+# message after it durably records a PR-open transition (once per run/PR). Leave
+# it unset to disable Slack notifications entirely — DB persistence and the PR
+# watcher hand-off are unaffected. This is a secret: keep the real value only in
+# ~/.u_agents_env.zsh, never commit it. Uncomment and fill in to enable:
+# export U_AGENTS_SLACK_WEBHOOK_URL="https://hooks.slack.com/services/XXX/YYY/ZZZ"

--- a/docs/u-agents.md
+++ b/docs/u-agents.md
@@ -181,6 +181,12 @@ Required runner environment for DB-backed operation:
 | `U_AGENTS_RUNNER_ID` | Stable runner identity from config/env. |
 | `U_AGENTS_MACHINE_ID` | Stable machine identity from config/env. |
 
+Optional runner environment:
+
+| Name | Meaning |
+| ---- | ------- |
+| `U_AGENTS_SLACK_WEBHOOK_URL` | Slack incoming-webhook URL. When set, `mark_pr_open` posts one Slack message per run/PR after the DB transition commits. Unset disables Slack entirely with no other behaviour change. It is a secret — keep the real value only in `~/.u_agents_env.zsh`, never in a tracked file. |
+
 Agents must not invent `U_AGENTS_RUNNER_ID` or `U_AGENTS_MACHINE_ID`.
 Blank values and placeholders such as `runner`, `machine`, `placeholder`,
 `changeme`, `todo`, or `example` are rejected. Launcher dry-runs require the
@@ -370,6 +376,39 @@ uses), so the next PR-watcher pass takes over. It needs the runner env and
 
 The PM prompt (`prompts/pm.md`) includes this as a required, non-optional step
 right after `gh pr create`.
+
+#### Slack notification (optional)
+
+When `U_AGENTS_SLACK_WEBHOOK_URL` is set, `mark_pr_open` sends one Slack message
+**after** the `phase=pr_open` / `pr_number` transition has committed — the DB row
+stays the source of truth and the PR-watcher hand-off, Slack is only a
+side-channel. The message looks like:
+
+```text
+u_agents opened PR
+<repo>#<issue> -> PR #<pr>
+https://github.com/<repo>/pull/<pr>
+branch: <branch>
+runner: <runner_id> / <machine_id>
+```
+
+Delivery is best-effort and never gates the durable flow:
+
+- **Unset webhook** — no Slack call; behaviour is identical to before.
+- **Delivery failure** — logs a `WARN` to stderr and the CLI still exits `0`
+  once the DB transition succeeded, so the PR watcher still takes over.
+- **At most once** — `mark_pr_open` is also re-run to re-arm the watcher after
+  review fixes. Before any webhook call, it persists a
+  `metadata.slack_pr_open_notified = {"pr_number": <pr>}` marker (merged into the
+  existing jsonb, so the durable contract is unchanged); later re-arms for the
+  same PR see the marker and are suppressed. Because the marker is stored
+  *before* delivery, a send that fails (or is ambiguous) after the marker is
+  written is **not** retried on a later re-arm — the at-most-once guarantee is
+  preferred over re-sending. If the marker itself cannot be persisted, the Slack
+  send is skipped entirely so no un-suppressable duplicate can occur.
+
+The webhook URL is a secret: keep it only in `~/.u_agents_env.zsh` (the PM
+pane's env), never in a tracked file.
 
 ### PR Watcher
 

--- a/tests/test_agent_runs.py
+++ b/tests/test_agent_runs.py
@@ -227,6 +227,25 @@ class TestAgentRunsClientWrites(unittest.TestCase):
         self.assertEqual(params["phase"], "fixing")
         self.assertTrue(params["increment_fix_rounds"])
 
+    def test_merge_metadata_only_updates_metadata(self):
+        conn = FakeConn([_row(metadata={"slack_pr_open_notified": {"pr_number": 240}})])
+        client = AgentRunsClient(conn, self.identity)
+
+        run = client.merge_metadata(
+            "o/r",
+            12,
+            {"slack_pr_open_notified": {"pr_number": 240}},
+        )
+
+        self.assertEqual(run.metadata, {"slack_pr_open_notified": {"pr_number": 240}})
+        sql, params = conn.calls[0]
+        self.assertIn("SET metadata = metadata || %(metadata)s::jsonb", sql)
+        self.assertNotIn("block_reason =", sql)
+        self.assertEqual(
+            json.loads(params["metadata"]),
+            {"slack_pr_open_notified": {"pr_number": 240}},
+        )
+
     def test_mark_pr_open_sets_pr_open_phase_and_number(self):
         conn = FakeConn([_row(phase="pr_open", pr_number=240)])
         client = AgentRunsClient(conn, self.identity)

--- a/tests/test_mark_pr_open.py
+++ b/tests/test_mark_pr_open.py
@@ -1,9 +1,14 @@
+import io
 import unittest
+from contextlib import redirect_stderr
 from dataclasses import replace
 from unittest import mock
 
 from u_agents.agent_runs import AgentRun
 from u_agents.mark_pr_open import main, record_pr_open
+from u_agents.slack_notify import SLACK_PR_OPEN_NOTIFIED_KEY
+
+WEBHOOK = "https://hooks.slack.example/T000/B000/secret"
 
 
 def _run(**overrides):
@@ -30,11 +35,20 @@ class FakeDbClient:
     def __init__(self, run=None):
         self.run = run or _run()
         self.calls = []
+        self.update_calls = []
         self.closed = False
 
     def mark_pr_open(self, repo_full, issue_number, *, pr_number, metadata=None):
         self.calls.append(("mark_pr_open", repo_full, issue_number, pr_number, metadata))
         return replace(self.run, phase="pr_open", pr_number=pr_number)
+
+    def update_pr_fields(self, repo_full, issue_number, **kwargs):
+        self.update_calls.append((repo_full, issue_number, kwargs))
+        return replace(self.run, phase="pr_open")
+
+    def merge_metadata(self, repo_full, issue_number, metadata):
+        self.update_calls.append((repo_full, issue_number, {"metadata": metadata}))
+        return replace(self.run, phase="pr_open")
 
     def close(self):
         self.closed = True
@@ -52,6 +66,14 @@ class TestRecordPrOpen(unittest.TestCase):
 
 
 class TestMain(unittest.TestCase):
+    # Default: Slack webhook unset so existing behaviour is unchanged.
+    def setUp(self):
+        patcher = mock.patch.dict(
+            "os.environ", {"U_AGENTS_SLACK_WEBHOOK_URL": ""}, clear=False
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_main_records_pr_open_and_closes_client(self):
         db = FakeDbClient()
         with mock.patch(
@@ -61,6 +83,8 @@ class TestMain(unittest.TestCase):
 
         self.assertEqual(rc, 0)
         self.assertEqual(db.calls, [("mark_pr_open", "o/r", 12, 240, None)])
+        # No webhook configured -> no Slack send, no marker persisted.
+        self.assertEqual(db.update_calls, [])
         self.assertTrue(db.closed)
 
     def test_main_closes_client_even_on_error(self):
@@ -86,6 +110,57 @@ class TestMain(unittest.TestCase):
             with self.subTest(argv=argv):
                 with self.assertRaises(SystemExit):
                     main(argv)
+
+    def test_main_sends_slack_when_webhook_set(self):
+        db = FakeDbClient()
+        posts = []
+        with mock.patch.dict(
+            "os.environ", {"U_AGENTS_SLACK_WEBHOOK_URL": WEBHOOK}, clear=False
+        ), mock.patch(
+            "u_agents.mark_pr_open.AgentRunsClient.from_env", return_value=db,
+        ), mock.patch(
+            "u_agents.slack_notify.post_to_webhook",
+            side_effect=lambda url, text: posts.append((url, text)),
+        ):
+            rc = main(["--repo", "o/r", "--issue", "12", "--pr", "240"])
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(posts), 1)
+        self.assertEqual(posts[0][0], WEBHOOK)
+        self.assertIn("o/r#12 -> PR #240", posts[0][1])
+        # Dedup marker persisted before the send (marker-first ordering).
+        self.assertEqual(len(db.update_calls), 1)
+        self.assertEqual(
+            db.update_calls[0][2]["metadata"],
+            {SLACK_PR_OPEN_NOTIFIED_KEY: {"pr_number": 240}},
+        )
+        self.assertTrue(db.closed)
+
+    def test_main_succeeds_when_slack_delivery_fails(self):
+        db = FakeDbClient()
+        buf = io.StringIO()
+        with mock.patch.dict(
+            "os.environ", {"U_AGENTS_SLACK_WEBHOOK_URL": WEBHOOK}, clear=False
+        ), mock.patch(
+            "u_agents.mark_pr_open.AgentRunsClient.from_env", return_value=db,
+        ), mock.patch(
+            "u_agents.slack_notify.post_to_webhook",
+            side_effect=RuntimeError("slack down"),
+        ), redirect_stderr(buf):
+            rc = main(["--repo", "o/r", "--issue", "12", "--pr", "240"])
+
+        # DB persistence succeeded, so the CLI still exits 0 despite Slack error.
+        self.assertEqual(rc, 0)
+        self.assertEqual(db.calls, [("mark_pr_open", "o/r", 12, 240, None)])
+        # Dedup marker is persisted before the (failed) send, so a re-arm stays
+        # suppressed and the ambiguous delivery is not retried.
+        self.assertEqual(len(db.update_calls), 1)
+        self.assertEqual(
+            db.update_calls[0][2]["metadata"],
+            {SLACK_PR_OPEN_NOTIFIED_KEY: {"pr_number": 240}},
+        )
+        self.assertIn("WARN: Slack PR-open notification failed", buf.getvalue())
+        self.assertTrue(db.closed)
 
 
 if __name__ == "__main__":

--- a/tests/test_slack_notify.py
+++ b/tests/test_slack_notify.py
@@ -1,0 +1,189 @@
+import io
+import unittest
+from contextlib import redirect_stderr
+from dataclasses import replace
+
+from u_agents.agent_runs import AgentRun
+from u_agents.slack_notify import (
+    SLACK_PR_OPEN_NOTIFIED_KEY,
+    already_notified,
+    build_pr_open_message,
+    notify_pr_open,
+    webhook_url_from_env,
+)
+
+WEBHOOK = "https://hooks.slack.example/T000/B000/secret"
+WEBHOOK_ENV = {"U_AGENTS_SLACK_WEBHOOK_URL": WEBHOOK}
+
+
+def _run(**overrides):
+    base = AgentRun(
+        repository_full_name="o/r",
+        github_issue_number=12,
+        parent_branch="main",
+        branch_name="feat/12",
+        phase="pr_open",
+        runner_id="runner-1",
+        machine_id="machine-1",
+        locked_by="runner-1@machine-1",
+        lease_until="future",
+        worktree_basename="12",
+        tmux_window="r-12",
+        pm_pane="agents:r-12.0",
+        pr_number=240,
+        metadata={},
+    )
+    return replace(base, **overrides)
+
+
+class FakeDbClient:
+    def __init__(self):
+        self.update_calls = []
+
+    def merge_metadata(self, repo_full, issue_number, metadata):
+        self.update_calls.append((repo_full, issue_number, {"metadata": metadata}))
+        return _run()
+
+
+class RecordingPoster:
+    def __init__(self, exc=None):
+        self.calls = []
+        self.exc = exc
+
+    def __call__(self, url, text):
+        self.calls.append((url, text))
+        if self.exc is not None:
+            raise self.exc
+
+
+class TestWebhookUrlFromEnv(unittest.TestCase):
+    def test_unset_returns_none(self):
+        self.assertIsNone(webhook_url_from_env({}))
+
+    def test_blank_returns_none(self):
+        self.assertIsNone(webhook_url_from_env({"U_AGENTS_SLACK_WEBHOOK_URL": "   "}))
+
+    def test_set_returns_stripped_value(self):
+        self.assertEqual(
+            webhook_url_from_env({"U_AGENTS_SLACK_WEBHOOK_URL": f"  {WEBHOOK} "}),
+            WEBHOOK,
+        )
+
+
+class TestAlreadyNotified(unittest.TestCase):
+    def test_false_without_marker(self):
+        self.assertFalse(already_notified(_run(), 240))
+
+    def test_true_when_marker_matches_pr(self):
+        run = _run(metadata={SLACK_PR_OPEN_NOTIFIED_KEY: {"pr_number": 240}})
+        self.assertTrue(already_notified(run, 240))
+
+    def test_false_when_marker_is_for_other_pr(self):
+        run = _run(metadata={SLACK_PR_OPEN_NOTIFIED_KEY: {"pr_number": 99}})
+        self.assertFalse(already_notified(run, 240))
+
+
+class TestBuildMessage(unittest.TestCase):
+    def test_message_contains_required_lines(self):
+        msg = build_pr_open_message(_run())
+        self.assertIn("u_agents opened PR", msg)
+        self.assertIn("o/r#12 -> PR #240", msg)
+        self.assertIn("https://github.com/o/r/pull/240", msg)
+        self.assertIn("branch: feat/12", msg)
+        self.assertIn("runner: runner-1 / machine-1", msg)
+
+
+class TestNotifyPrOpen(unittest.TestCase):
+    def test_unset_env_is_noop(self):
+        db = FakeDbClient()
+        poster = RecordingPoster()
+
+        sent = notify_pr_open(db, _run(), env={}, post=poster)
+
+        self.assertFalse(sent)
+        self.assertEqual(poster.calls, [])
+        self.assertEqual(db.update_calls, [])
+
+    def test_successful_send_posts_once_and_persists_marker(self):
+        db = FakeDbClient()
+        poster = RecordingPoster()
+
+        sent = notify_pr_open(db, _run(), env=WEBHOOK_ENV, post=poster)
+
+        self.assertTrue(sent)
+        self.assertEqual(len(poster.calls), 1)
+        url, text = poster.calls[0]
+        self.assertEqual(url, WEBHOOK)
+        self.assertIn("o/r#12 -> PR #240", text)
+        self.assertEqual(len(db.update_calls), 1)
+        repo_full, issue_number, kwargs = db.update_calls[0]
+        self.assertEqual((repo_full, issue_number), ("o/r", 12))
+        self.assertEqual(
+            kwargs["metadata"], {SLACK_PR_OPEN_NOTIFIED_KEY: {"pr_number": 240}}
+        )
+
+    def test_delivery_failure_warns_and_does_not_raise(self):
+        db = FakeDbClient()
+        poster = RecordingPoster(exc=RuntimeError("slack down"))
+
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            sent = notify_pr_open(db, _run(), env=WEBHOOK_ENV, post=poster)
+
+        self.assertFalse(sent)
+        self.assertEqual(len(poster.calls), 1)
+        # Marker persisted BEFORE the (failed) send, so a later re-arm stays
+        # suppressed: at-most-once is preferred over retrying an ambiguous send.
+        self.assertEqual(len(db.update_calls), 1)
+        self.assertEqual(
+            db.update_calls[0][2]["metadata"],
+            {SLACK_PR_OPEN_NOTIFIED_KEY: {"pr_number": 240}},
+        )
+        self.assertIn("WARN: Slack PR-open notification failed", buf.getvalue())
+
+    def test_duplicate_suppressed_when_marker_present(self):
+        db = FakeDbClient()
+        poster = RecordingPoster()
+        run = _run(metadata={SLACK_PR_OPEN_NOTIFIED_KEY: {"pr_number": 240}})
+
+        sent = notify_pr_open(db, run, env=WEBHOOK_ENV, post=poster)
+
+        self.assertFalse(sent)
+        self.assertEqual(poster.calls, [])
+        self.assertEqual(db.update_calls, [])
+
+    def test_marker_persist_failure_skips_send_and_does_not_raise(self):
+        class BoomDb(FakeDbClient):
+            def merge_metadata(self, *_a, **_kw):
+                raise RuntimeError("db down")
+
+        poster = RecordingPoster()
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            sent = notify_pr_open(BoomDb(), _run(), env=WEBHOOK_ENV, post=poster)
+
+        self.assertFalse(sent)
+        # Marker could not be persisted -> never call Slack (no un-suppressable
+        # duplicate).
+        self.assertEqual(poster.calls, [])
+        self.assertIn("WARN: Slack PR-open notify marker persist failed", buf.getvalue())
+
+    def test_marker_is_persisted_before_send(self):
+        events = []
+
+        class OrderedDb(FakeDbClient):
+            def merge_metadata(self, repo_full, issue_number, metadata):
+                events.append("marker")
+                return super().merge_metadata(repo_full, issue_number, metadata)
+
+        def poster(url, text):
+            events.append("send")
+
+        sent = notify_pr_open(OrderedDb(), _run(), env=WEBHOOK_ENV, post=poster)
+
+        self.assertTrue(sent)
+        self.assertEqual(events, ["marker", "send"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/u_agents/README.md
+++ b/u_agents/README.md
@@ -12,6 +12,7 @@ Layout:
 - `watchdog.py` — stall detector (`python3 -m u_agents.watchdog`).
 - `pr_watcher.py` — DB-backed PR phase watcher (`python3 -m u_agents.pr_watcher`).
 - `mark_pr_open.py` — PM-run CLI to record an opened PR (`phase=pr_open`, `pr_number`).
+- `slack_notify.py` — optional, best-effort Slack PR-open webhook (`U_AGENTS_SLACK_WEBHOOK_URL`).
 - `prompts/pm.md` — PM prompt template sent into the tmux PM pane.
 - `compose.yml` — local PostgreSQL 17 for v0.2 control-plane development.
 - `db/` — `agent_runs` schema and contract docs.

--- a/u_agents/agent_runs.py
+++ b/u_agents/agent_runs.py
@@ -362,6 +362,28 @@ class AgentRunsClient:
             "metadata": json.dumps(dict(metadata or {})),
         })
 
+    def merge_metadata(
+        self,
+        repository_full_name: str,
+        github_issue_number: int,
+        metadata: Mapping[str, Any],
+    ) -> AgentRun:
+        validate_repository_full_name(repository_full_name)
+        validate_issue_number(github_issue_number)
+        validate_metadata(metadata)
+        sql = f"""
+            UPDATE agent_runs
+            SET metadata = metadata || %(metadata)s::jsonb
+            WHERE repository_full_name = %(repository_full_name)s
+              AND github_issue_number = %(github_issue_number)s
+            RETURNING {_row_columns()}
+        """
+        return self._require_row(sql, {
+            "repository_full_name": repository_full_name,
+            "github_issue_number": github_issue_number,
+            "metadata": json.dumps(dict(metadata)),
+        })
+
     def mark_pr_open(
         self,
         repository_full_name: str,

--- a/u_agents/mark_pr_open.py
+++ b/u_agents/mark_pr_open.py
@@ -20,6 +20,7 @@ import argparse
 import sys
 
 from u_agents.agent_runs import AgentRun, AgentRunsClient
+from u_agents.slack_notify import notify_pr_open
 
 
 def record_pr_open(
@@ -55,6 +56,10 @@ def main(argv=None) -> int:
     db_client = AgentRunsClient.from_env()
     try:
         run = record_pr_open(db_client, args.repo, args.issue, args.pr)
+        # Best-effort Slack notification, only after the DB transition above has
+        # committed. No-op when U_AGENTS_SLACK_WEBHOOK_URL is unset; a delivery
+        # failure warns but never fails the CLI or the PR-watcher hand-off.
+        notify_pr_open(db_client, run)
     finally:
         db_client.close()
     print(

--- a/u_agents/slack_notify.py
+++ b/u_agents/slack_notify.py
@@ -1,0 +1,156 @@
+"""Optional Slack webhook notification for the PR-open transition.
+
+This is a best-effort side-channel on top of the durable ``agent_runs``
+transition. The DB row reaching ``phase = 'pr_open'`` with ``pr_number`` set
+(via :meth:`AgentRunsClient.mark_pr_open`) remains the source of truth and the
+PR-watcher hand-off; Slack delivery never gates it:
+
+* When ``U_AGENTS_SLACK_WEBHOOK_URL`` is unset the helpers are no-ops, so
+  behaviour is identical to before this module existed.
+* A delivery failure logs a ``WARN`` to stderr and is swallowed, so the CLI
+  still exits successfully once the DB transition has committed.
+* The notification is sent at most once per run/PR. ``mark_pr_open`` is also
+  used to re-arm the PR watcher after review fixes, so a persisted
+  ``slack_pr_open_notified`` metadata marker (carrying the ``pr_number``)
+  suppresses duplicate messages on later re-arms. The marker is persisted
+  *before* the webhook call, so at-most-once holds even if delivery is
+  ambiguous: a delivery that fails after the marker is stored is not retried on
+  a later re-arm (the at-most-once guarantee is preferred over re-sending an
+  ambiguous webhook).
+
+Only the Python standard library is used (``urllib.request``) so the runner
+needs no extra dependency beyond what the DB commands already require.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from typing import Callable, Mapping
+
+from u_agents.agent_runs import AgentRun
+
+ENV_SLACK_WEBHOOK_URL = "U_AGENTS_SLACK_WEBHOOK_URL"
+SLACK_PR_OPEN_NOTIFIED_KEY = "slack_pr_open_notified"
+
+_DEFAULT_TIMEOUT_SECONDS = 10.0
+
+# Type of the injectable webhook sender (url, text) -> None.
+Poster = Callable[[str, str], None]
+
+
+def webhook_url_from_env(env: Mapping[str, object] | None = None) -> str | None:
+    """Return the configured Slack webhook URL, or ``None`` when unset/blank."""
+    source = os.environ if env is None else env
+    value = source.get(ENV_SLACK_WEBHOOK_URL, "")
+    if not isinstance(value, str) or value.strip() == "":
+        return None
+    return value.strip()
+
+
+def already_notified(run: AgentRun, pr_number: int) -> bool:
+    """Whether this run already sent a Slack PR-open message for ``pr_number``.
+
+    Reads the persisted ``slack_pr_open_notified`` marker. The marker is keyed
+    by ``pr_number`` so a brand-new PR for the same run (unusual, but possible)
+    is not silently suppressed by a stale marker.
+    """
+    metadata = run.metadata or {}
+    marker = metadata.get(SLACK_PR_OPEN_NOTIFIED_KEY)
+    if isinstance(marker, Mapping):
+        return marker.get("pr_number") == pr_number
+    return False
+
+
+def build_pr_open_message(run: AgentRun) -> str:
+    """Render the Slack message body for an opened PR."""
+    repo = run.repository_full_name
+    pr = run.pr_number
+    return "\n".join(
+        [
+            "u_agents opened PR",
+            f"{repo}#{run.github_issue_number} -> PR #{pr}",
+            f"https://github.com/{repo}/pull/{pr}",
+            f"branch: {run.branch_name}",
+            f"runner: {run.runner_id} / {run.machine_id}",
+        ]
+    )
+
+
+def post_to_webhook(
+    url: str, text: str, *, timeout: float = _DEFAULT_TIMEOUT_SECONDS
+) -> None:
+    """POST ``{"text": ...}`` to a Slack incoming webhook.
+
+    Raises on transport or non-2xx HTTP errors; callers treat any exception as
+    a non-fatal delivery failure.
+    """
+    data = json.dumps({"text": text}).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        # Slack replies 200 with body "ok"; drain it so the socket closes.
+        response.read()
+
+
+def notify_pr_open(
+    db_client,
+    run: AgentRun,
+    *,
+    env: Mapping[str, object] | None = None,
+    post: Poster | None = None,
+) -> bool:
+    """Send a one-time Slack PR-open notification, best-effort.
+
+    Returns ``True`` only when the dedup marker was persisted *and* a message
+    was delivered. Returns ``False`` (without raising) when the webhook is
+    unset, the run was already notified, the marker could not be persisted, or
+    delivery failed. ``post`` is injectable for tests; it defaults to
+    :func:`post_to_webhook`.
+    """
+    url = webhook_url_from_env(env)
+    if url is None or run.pr_number is None:
+        return False
+    if already_notified(run, run.pr_number):
+        return False
+
+    # Persist the dedup marker BEFORE delivering, so the at-most-once guarantee
+    # is durable: once the marker is stored, a later mark_pr_open re-arm sees it
+    # and never re-sends, even if this delivery turns out ambiguous. If the
+    # marker cannot be persisted we skip the send entirely rather than risk an
+    # un-suppressable duplicate.
+    try:
+        db_client.merge_metadata(
+            run.repository_full_name,
+            run.github_issue_number,
+            {SLACK_PR_OPEN_NOTIFIED_KEY: {"pr_number": run.pr_number}},
+        )
+    except Exception as exc:  # noqa: BLE001 - DB row already committed pr_open
+        print(
+            f"WARN: Slack PR-open notify marker persist failed for "
+            f"{run.repository_full_name}#{run.github_issue_number} "
+            f"(PR #{run.pr_number}); skipping Slack send: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return False
+
+    sender = post if post is not None else post_to_webhook
+    try:
+        sender(url, build_pr_open_message(run))
+    except Exception as exc:  # noqa: BLE001 - delivery is best-effort
+        # The marker is already stored, so this is not retried on a later
+        # re-arm: at-most-once is preferred over re-sending an ambiguous webhook.
+        print(
+            f"WARN: Slack PR-open notification failed for "
+            f"{run.repository_full_name}#{run.github_issue_number} "
+            f"(PR #{run.pr_number}): {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return False
+    return True


### PR DESCRIPTION
## Summary

- Add optional Slack incoming-webhook notification after `u_agents.mark_pr_open` durably records a PR-open transition.
- Persist a `slack_pr_open_notified` metadata marker before delivery so watcher re-arms do not duplicate Slack messages.
- Document `U_AGENTS_SLACK_WEBHOOK_URL` as a local secret and keep real values out of git.

## Changes

- Adds `u_agents.slack_notify` using stdlib `urllib.request` with injectable posting for tests.
- Wires `mark_pr_open` to send the best-effort notification after DB persistence.
- Adds `AgentRunsClient.merge_metadata` so the Slack marker write does not touch `block_reason` or PR phase fields.
- Covers unset env, successful send, delivery failure, duplicate suppression, marker ordering, and metadata-only persistence.

## Validation

- `python3 -m unittest tests.test_agent_runs tests.test_slack_notify tests.test_mark_pr_open -v`
- `python3 -m unittest discover -s tests`
- `python3 -m u_agents.mark_pr_open --help`

Closes #18
