### PR TITLE
u_agents: store PR review comments in review_comments table and persist PM resolutions

### DIFF
--- a/tests/test_agent_runs.py
+++ b/tests/test_agent_runs.py
@@ -7,6 +7,8 @@ from u_agents.agent_runs import (
     ClaimPayload,
     ReviewCommentRecord,
     build_claim_payload,
+    validate_comment_key,
+    validate_verification_refs,
 )
 from u_agents.contract import REVIEW_RESULT_RELATIVE_PATH, RepoConfig
 from u_agents.control_plane import RunnerIdentity
@@ -70,6 +72,24 @@ class FakeConn:
 
     def commit(self):
         self.commits += 1
+
+
+class TestReviewCommentValidators(unittest.TestCase):
+    def test_comment_key_requires_colon_and_non_empty_parts(self):
+        for bad in ("", "   ", "nocolon", ":abc", "1:", "  :  "):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    validate_comment_key(bad)
+
+    def test_comment_key_accepts_signed_id_and_hash(self):
+        # Synthetic review signals use deterministic signed ids; keep them valid.
+        for good in ("3409641728:1cf66a90f911", "-123:deadbeef", "1:abc"):
+            with self.subTest(good=good):
+                self.assertEqual(validate_comment_key(good), good)
+
+    def test_verification_refs_non_serializable_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            validate_verification_refs([object()])
 
 
 class TestClaimPayload(unittest.TestCase):

--- a/tests/test_agent_runs.py
+++ b/tests/test_agent_runs.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from u_agents.agent_runs import (
     AgentRunsClient,
     ClaimPayload,
+    ReviewCommentRecord,
     build_claim_payload,
 )
 from u_agents.contract import REVIEW_RESULT_RELATIVE_PATH, RepoConfig
@@ -303,6 +304,245 @@ class TestAgentRunsClientWrites(unittest.TestCase):
             client = AgentRunsClient(conn, self.identity)
             getattr(client, method)()
             self.assertEqual(conn.commits, 1, f"{method} should commit once")
+
+
+def _rc_row(**overrides):
+    base = {
+        "agent_run_id": "run-uuid",
+        "github_comment_id": 3409641728,
+        "body_hash": "1cf66a90f911",
+        "comment_key": "3409641728:1cf66a90f911",
+        "pr_number": 41,
+        "source": "inline_review",
+        "watcher_verdict": "needs_user_judgment",
+        "pm_decision": None,
+        "resolution_status": "unresolved",
+        "original_body": "guard context.mounted",
+        "original_path": "a.dart",
+        "original_line": 144,
+        "original_commit_sha": None,
+        "handed_off_at": None,
+        "resolved_at": None,
+        "addressed_by_commit_sha": None,
+        "verification_summary": None,
+        "verification_refs": [],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestReviewCommentsClient(unittest.TestCase):
+    def setUp(self):
+        self.identity = RunnerIdentity("runner-1", "machine-1")
+
+    def _client(self, rows):
+        return AgentRunsClient(FakeConn(rows), self.identity)
+
+    # ----- upsert ----------------------------------------------------------
+
+    def test_upsert_review_comment_generates_insert_select_on_conflict(self):
+        conn = FakeConn([_rc_row()])
+        client = AgentRunsClient(conn, self.identity)
+
+        record = client.upsert_review_comment(
+            "o/r", 41,
+            github_comment_id=3409641728,
+            body_hash="1cf66a90f911",
+            pr_number=41,
+            source="inline_review",
+            watcher_verdict="needs_user_judgment",
+            original_body="guard context.mounted",
+            original_path="a.dart",
+            original_line=144,
+        )
+
+        self.assertIsInstance(record, ReviewCommentRecord)
+        self.assertEqual(record.comment_key, "3409641728:1cf66a90f911")
+        self.assertEqual(record.resolution_status, "unresolved")
+        self.assertEqual(conn.commits, 1)
+        sql, params = conn.calls[0]
+        self.assertIn("INSERT INTO review_comments", sql)
+        self.assertIn("SELECT run_id", sql)
+        self.assertIn("ON CONFLICT ON CONSTRAINT review_comments_pkey DO UPDATE", sql)
+        self.assertIn("RETURNING", sql)
+        self.assertEqual(params["github_comment_id"], 3409641728)
+        self.assertEqual(params["body_hash"], "1cf66a90f911")
+        self.assertEqual(params["watcher_verdict"], "needs_user_judgment")
+
+    def test_upsert_preserves_pm_resolution_columns_on_conflict(self):
+        # The duplicate comment_key must update the same row WITHOUT clobbering
+        # the PM-owned resolution columns; the upsert SET clause must not touch
+        # them at all.
+        conn = FakeConn([_rc_row()])
+        client = AgentRunsClient(conn, self.identity)
+        client.upsert_review_comment(
+            "o/r", 41,
+            github_comment_id=1, body_hash="abc", pr_number=41,
+            source="inline_review", watcher_verdict="valid_optional",
+        )
+        sql, _params = conn.calls[0]
+        # Only the ON CONFLICT ... SET clause (before RETURNING) decides what is
+        # overwritten; RETURNING legitimately lists every column.
+        update_clause = sql.split("DO UPDATE", 1)[1].split("RETURNING", 1)[0]
+        for owned in (
+            "resolution_status",
+            "pm_decision",
+            "handed_off_at",
+            "resolved_at",
+            "addressed_by_commit_sha",
+            "verification_summary",
+            "verification_refs",
+        ):
+            with self.subTest(column=owned):
+                self.assertNotIn(owned, update_clause)
+        # It does refresh the watcher-observed fields and last_seen_at.
+        self.assertIn("watcher_verdict = EXCLUDED.watcher_verdict", update_clause)
+        self.assertIn("last_seen_at = now()", update_clause)
+
+    def test_upsert_validates_inputs_before_db(self):
+        for kwargs in (
+            {"source": "bogus"},
+            {"watcher_verdict": "bogus"},
+            {"pr_number": 0},
+            {"body_hash": "  "},
+        ):
+            with self.subTest(kwargs=kwargs):
+                conn = FakeConn([_rc_row()])
+                client = AgentRunsClient(conn, self.identity)
+                base = {
+                    "github_comment_id": 1,
+                    "body_hash": "abc",
+                    "pr_number": 41,
+                    "source": "inline_review",
+                    "watcher_verdict": "needs_user_judgment",
+                }
+                base.update(kwargs)
+                with self.assertRaises(ValueError):
+                    client.upsert_review_comment("o/r", 41, **base)
+                self.assertEqual(conn.calls, [])
+
+    def test_upsert_raises_when_agent_run_missing(self):
+        conn = FakeConn([])  # INSERT...SELECT matched no agent_runs row
+        client = AgentRunsClient(conn, self.identity)
+        with self.assertRaises(RuntimeError):
+            client.upsert_review_comment(
+                "o/r", 41, github_comment_id=1, body_hash="abc", pr_number=41,
+                source="inline_review", watcher_verdict="needs_user_judgment",
+            )
+
+    # ----- hand-off --------------------------------------------------------
+
+    def test_mark_review_comment_handed_off_is_idempotent_coalesce(self):
+        conn = FakeConn([_rc_row(handed_off_at="2026-06-14T00:00:00Z")])
+        client = AgentRunsClient(conn, self.identity)
+        record = client.mark_review_comment_handed_off(
+            "o/r", 41, "3409641728:1cf66a90f911",
+        )
+        self.assertIsNotNone(record.handed_off_at)
+        sql, params = conn.calls[0]
+        self.assertIn("UPDATE review_comments", sql)
+        self.assertIn("handed_off_at = COALESCE(rc.handed_off_at, now())", sql)
+        self.assertEqual(params["comment_key"], "3409641728:1cf66a90f911")
+
+    def test_mark_review_comment_handed_off_raises_when_missing(self):
+        conn = FakeConn([])
+        client = AgentRunsClient(conn, self.identity)
+        with self.assertRaises(RuntimeError):
+            client.mark_review_comment_handed_off("o/r", 41, "9:deadbeef")
+
+    # ----- record resolution ----------------------------------------------
+
+    def test_record_resolution_addressed_writes_commit_and_verification(self):
+        conn = FakeConn([_rc_row(
+            resolution_status="addressed", pm_decision="valid_must_fix",
+            addressed_by_commit_sha="b6cd1ad",
+            verification_summary="guarded; tests green", resolved_at="2026-06-14",
+        )])
+        client = AgentRunsClient(conn, self.identity)
+        record = client.record_review_comment_resolution(
+            "o/r", 41, "3409641728:1cf66a90f911",
+            resolution_status="addressed", pm_decision="valid_must_fix",
+            addressed_by_commit_sha="b6cd1ad",
+            verification_summary="guarded; tests green",
+            verification_refs=["https://ci/run/1"],
+        )
+        self.assertEqual(record.resolution_status, "addressed")
+        sql, params = conn.calls[0]
+        self.assertIn("UPDATE review_comments", sql)
+        self.assertIn("resolution_status = %(resolution_status)s", sql)
+        self.assertIn("WHEN %(resolution_status)s = 'unresolved' THEN NULL", sql)
+        self.assertEqual(params["addressed_by_commit_sha"], "b6cd1ad")
+        self.assertEqual(json.loads(params["verification_refs"]), ["https://ci/run/1"])
+
+    def test_record_resolution_addressed_requires_commit_and_verification(self):
+        for kwargs in (
+            {"addressed_by_commit_sha": None, "verification_summary": "v"},
+            {"addressed_by_commit_sha": "sha", "verification_summary": None},
+            {"addressed_by_commit_sha": "  ", "verification_summary": "v"},
+            {"addressed_by_commit_sha": "sha", "verification_summary": "   "},
+        ):
+            with self.subTest(kwargs=kwargs):
+                conn = FakeConn([_rc_row()])
+                client = AgentRunsClient(conn, self.identity)
+                with self.assertRaises(ValueError):
+                    client.record_review_comment_resolution(
+                        "o/r", 41, "1:abc", resolution_status="addressed", **kwargs,
+                    )
+                self.assertEqual(conn.calls, [])
+
+    def test_record_resolution_rejected_and_judgment_require_reason(self):
+        for status in ("rejected", "needs_user_judgment"):
+            with self.subTest(status=status):
+                conn = FakeConn([_rc_row()])
+                client = AgentRunsClient(conn, self.identity)
+                with self.assertRaises(ValueError):
+                    client.record_review_comment_resolution(
+                        "o/r", 41, "1:abc", resolution_status=status,
+                        verification_summary=None,
+                    )
+                self.assertEqual(conn.calls, [])
+
+    def test_record_resolution_rejects_non_list_verification_refs(self):
+        conn = FakeConn([_rc_row()])
+        client = AgentRunsClient(conn, self.identity)
+        with self.assertRaises(ValueError):
+            client.record_review_comment_resolution(
+                "o/r", 41, "1:abc", resolution_status="rejected",
+                verification_summary="reason", verification_refs="not-a-list",
+            )
+        self.assertEqual(conn.calls, [])
+
+    def test_record_resolution_rejects_unknown_status_and_decision(self):
+        conn = FakeConn([_rc_row()])
+        client = AgentRunsClient(conn, self.identity)
+        with self.assertRaises(ValueError):
+            client.record_review_comment_resolution(
+                "o/r", 41, "1:abc", resolution_status="bogus",
+            )
+        with self.assertRaises(ValueError):
+            client.record_review_comment_resolution(
+                "o/r", 41, "1:abc", resolution_status="rejected",
+                pm_decision="bogus", verification_summary="reason",
+            )
+
+    def test_record_resolution_raises_when_missing(self):
+        conn = FakeConn([])
+        client = AgentRunsClient(conn, self.identity)
+        with self.assertRaises(RuntimeError):
+            client.record_review_comment_resolution(
+                "o/r", 41, "9:deadbeef", resolution_status="rejected",
+                verification_summary="reason",
+            )
+
+    def test_list_review_comments_joins_and_commits(self):
+        conn = FakeConn([_rc_row(), _rc_row(comment_key="2:def", github_comment_id=2)])
+        client = AgentRunsClient(conn, self.identity)
+        records = client.list_review_comments("o/r", 41)
+        self.assertEqual(len(records), 2)
+        self.assertEqual(conn.commits, 1)
+        sql, _params = conn.calls[0]
+        self.assertIn("FROM review_comments", sql)
+        self.assertIn("JOIN agent_runs", sql)
 
 
 if __name__ == "__main__":

--- a/tests/test_db_contract.py
+++ b/tests/test_db_contract.py
@@ -2,11 +2,18 @@ import re
 import unittest
 from pathlib import Path
 
-from u_agents.control_plane import AGENT_RUN_STATUSES, RUN_PHASE_STATUSES
+from u_agents.control_plane import (
+    AGENT_RUN_STATUSES,
+    REVIEW_COMMENT_RESOLUTION_STATUSES,
+    REVIEW_COMMENT_SOURCES,
+    REVIEW_COMMENT_VERDICTS,
+    RUN_PHASE_STATUSES,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = ROOT / "u_agents" / "db" / "001_agent_runs.sql"
+REVIEW_COMMENTS_SCHEMA = ROOT / "u_agents" / "db" / "003_review_comments.sql"
 DB_README = ROOT / "u_agents" / "db" / "README.md"
 COMPOSE = ROOT / "u_agents" / "compose.yml"
 
@@ -109,6 +116,108 @@ class TestAgentRunsSchema(unittest.TestCase):
         self.assertIn("CREATE TRIGGER agent_runs_set_updated_at", self.sql)
 
 
+class TestReviewCommentsSchema(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.sql = REVIEW_COMMENTS_SCHEMA.read_text(encoding="utf-8")
+
+    def test_table_and_generated_comment_key_exist(self):
+        self.assertIn("review_comments", self.sql)
+        self.assertIn(
+            "REFERENCES public.agent_runs(run_id)\n        ON DELETE CASCADE",
+            self.sql,
+        )
+        self.assertIn(
+            "comment_key text GENERATED ALWAYS AS (", self.sql,
+        )
+        self.assertIn("github_comment_id::text || ':' || body_hash", self.sql)
+        self.assertIn(
+            "PRIMARY KEY (agent_run_id, comment_key)", self.sql,
+        )
+
+    def test_required_columns_exist(self):
+        for column in (
+            "agent_run_id",
+            "github_comment_id",
+            "body_hash",
+            "comment_key",
+            "pr_number",
+            "source",
+            "watcher_verdict",
+            "pm_decision",
+            "resolution_status",
+            "original_body",
+            "original_path",
+            "original_line",
+            "original_commit_sha",
+            "handed_off_at",
+            "resolved_at",
+            "addressed_by_commit_sha",
+            "verification_summary",
+            "verification_refs",
+            "first_seen_at",
+            "last_seen_at",
+            "created_at",
+            "updated_at",
+        ):
+            with self.subTest(column=column):
+                self.assertRegex(self.sql, rf"\b{column}\b")
+
+    def test_enum_checks_match_python_contract(self):
+        for source in REVIEW_COMMENT_SOURCES:
+            with self.subTest(source=source):
+                self.assertIn(f"'{source}'", self.sql)
+        for verdict in REVIEW_COMMENT_VERDICTS:
+            with self.subTest(verdict=verdict):
+                self.assertIn(f"'{verdict}'", self.sql)
+        for status in REVIEW_COMMENT_RESOLUTION_STATUSES:
+            with self.subTest(resolution_status=status):
+                self.assertIn(f"'{status}'", self.sql)
+
+    def test_addressed_requires_commit_and_verification(self):
+        self.assertIn("review_comments_addressed_requires_commit_check", self.sql)
+        self.assertIn(
+            "review_comments_addressed_requires_verification_check", self.sql,
+        )
+        # addressed must carry a non-empty commit sha and verification summary.
+        self.assertIn("resolution_status <> 'addressed'", self.sql)
+        self.assertIn("btrim(addressed_by_commit_sha) <> ''", self.sql)
+        self.assertIn("btrim(verification_summary) <> ''", self.sql)
+
+    def test_rejected_and_judgment_require_reason(self):
+        self.assertIn("review_comments_terminal_reason_check", self.sql)
+        self.assertIn(
+            "resolution_status NOT IN ('rejected', 'needs_user_judgment')",
+            self.sql,
+        )
+        self.assertIn("verification_summary IS NOT NULL", self.sql)
+        self.assertIn("btrim(verification_summary) <> ''", self.sql)
+
+    def test_resolved_at_consistency_constraint(self):
+        self.assertIn("review_comments_resolved_at_check", self.sql)
+        self.assertIn("resolution_status = 'unresolved' AND resolved_at IS NULL", self.sql)
+        self.assertIn(
+            "resolution_status <> 'unresolved' AND resolved_at IS NOT NULL", self.sql,
+        )
+
+    def test_verification_refs_must_be_json_array(self):
+        self.assertIn("review_comments_verification_refs_array_check", self.sql)
+        self.assertIn("jsonb_typeof(verification_refs) = 'array'", self.sql)
+
+    def test_pr_number_and_body_hash_checks(self):
+        self.assertIn("review_comments_pr_number_check", self.sql)
+        self.assertIn("pr_number > 0", self.sql)
+        self.assertIn("review_comments_body_hash_check", self.sql)
+        self.assertIn("btrim(body_hash) <> ''", self.sql)
+
+    def test_indexes_and_updated_at_trigger(self):
+        self.assertIn("review_comments_run_resolution_idx", self.sql)
+        self.assertIn("review_comments_pr_idx", self.sql)
+        self.assertIn("review_comments_last_seen_idx", self.sql)
+        self.assertIn("CREATE TRIGGER review_comments_set_updated_at", self.sql)
+        self.assertIn("EXECUTE FUNCTION set_agent_runs_updated_at()", self.sql)
+
+
 class TestDbDocsContract(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -145,6 +254,30 @@ class TestDbDocsContract(unittest.TestCase):
         ):
             with self.subTest(text=text):
                 self.assertIn(text, self.readme)
+
+    def test_docs_describe_review_comments_table_and_ownership(self):
+        for text in (
+            "## Table: review_comments",
+            "### State ownership",
+            "### Watcher decision contract",
+            "u_agents.record_review_comment_resolution",
+            "`mark_pr_open`: only re-arms the PR watcher",
+            "records the resolution **before** re-arming",
+            "`resolution_status = 'addressed'` does not block",
+            "`resolution_status = 'rejected'` does not block",
+            "`resolution_status = 'needs_user_judgment'` blocks",
+            "`handed_off_at IS NULL` is handed off",
+            "`handed_off_at IS NOT NULL` blocks",
+            "no longer the source of truth",
+        ):
+            with self.subTest(text=text):
+                self.assertIn(text, self.readme)
+        for source in REVIEW_COMMENT_SOURCES:
+            with self.subTest(source=source):
+                self.assertIn(f"`{source}`", self.readme)
+        for status in REVIEW_COMMENT_RESOLUTION_STATUSES:
+            with self.subTest(resolution_status=status):
+                self.assertIn(f"`{status}`", self.readme)
 
 
 class TestComposeContract(unittest.TestCase):

--- a/tests/test_pm_prompt.py
+++ b/tests/test_pm_prompt.py
@@ -41,6 +41,20 @@ class TestPmPromptContent(unittest.TestCase):
             self.text,
         )
 
+    def test_records_review_comment_resolution_before_rearm(self):
+        # Issue #20: the PM must persist a durable resolution in the DB before
+        # re-arming the watcher; a GitHub comment is not durable state.
+        self.assertIn("# PR review comment resolution", self.text)
+        self.assertIn(
+            "PYTHONPATH={u_agents_root} {u_agents_python} "
+            "-m u_agents.record_review_comment_resolution",
+            self.text,
+        )
+        self.assertIn("BEFORE you re-arm the watcher", self.text)
+        self.assertRegex(self.text, r"addressed.*requires.*--commit-sha")
+        # mark_pr_open does not own review comment resolution.
+        self.assertIn("mark_pr_open` only\nre-arms the watcher", self.text)
+
 
 class TestPmPromptRenders(unittest.TestCase):
     """The whole template must still render: every {placeholder} added for the

--- a/tests/test_pr_watcher.py
+++ b/tests/test_pr_watcher.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 from unittest import mock
 
 from u_agents.agent_runs import AgentRun
+from u_agents.agent_runs import ReviewCommentRecord
 from u_agents.pr_watcher import (
     PR_VIEW_JSON_FIELDS,
     REVIEW_VERDICTS,
@@ -15,6 +16,7 @@ from u_agents.pr_watcher import (
     build_fix_prompt,
     build_validation_handoff_prompt,
     check_once,
+    db_source,
     default_validate_comment,
     extract_must_fix_review_comment_keys,
     fetch_pr_reality,
@@ -22,7 +24,7 @@ from u_agents.pr_watcher import (
     live_dispatch_handoff,
     mark_pr_open_command,
     reconcile_pr_run,
-    triage_review_comments,
+    record_resolution_command,
 )
 
 
@@ -70,10 +72,42 @@ def _reality(**overrides):
     return replace(base, **overrides)
 
 
+def _seed(comment, *, watcher_verdict="needs_user_judgment", source="inline_review",
+          resolution_status="unresolved", pm_decision=None, handed_off_at=None,
+          resolved_at=None, addressed_by_commit_sha=None, verification_summary=None,
+          verification_refs=None, pr_number=45):
+    """Build a pre-existing review_comments row dict for FakeDbClient, keyed by
+    the comment's stable_key (== the DB comment_key)."""
+    return {
+        "comment_key": comment.stable_key,
+        "github_comment_id": comment.github_comment_id,
+        "body_hash": comment.body_hash[:12],
+        "pr_number": pr_number,
+        "source": source,
+        "watcher_verdict": watcher_verdict,
+        "resolution_status": resolution_status,
+        "pm_decision": pm_decision,
+        "handed_off_at": handed_off_at,
+        "resolved_at": resolved_at,
+        "addressed_by_commit_sha": addressed_by_commit_sha,
+        "verification_summary": verification_summary,
+        "verification_refs": list(verification_refs or []),
+        "original_body": comment.body,
+        "original_path": comment.path,
+        "original_line": comment.line,
+        "original_commit_sha": None,
+    }
+
+
 class FakeDbClient:
-    def __init__(self, runs=None):
+    def __init__(self, runs=None, comments=None):
         self.runs = list(runs or [])
         self.calls = []
+        # comment_key -> mutable row dict, modeling the durable review_comments
+        # table (preserve PM resolution columns on watcher re-observation).
+        self.review_comments = {}
+        for row in comments or []:
+            self.review_comments[row["comment_key"]] = dict(row)
 
     def list_pr_watch_runs(self):
         return list(self.runs)
@@ -131,6 +165,103 @@ class FakeDbClient:
             block_reason=block_reason,
             metadata=metadata or {},
         )
+
+    # ----- review_comments (durable per-comment table) --------------------
+
+    def _record(self, key):
+        d = self.review_comments[key]
+        return ReviewCommentRecord(
+            agent_run_id="run-uuid",
+            github_comment_id=d["github_comment_id"],
+            body_hash=d["body_hash"],
+            comment_key=key,
+            pr_number=d["pr_number"],
+            source=d["source"],
+            watcher_verdict=d["watcher_verdict"],
+            resolution_status=d["resolution_status"],
+            pm_decision=d.get("pm_decision"),
+            handed_off_at=d.get("handed_off_at"),
+            resolved_at=d.get("resolved_at"),
+            addressed_by_commit_sha=d.get("addressed_by_commit_sha"),
+            verification_summary=d.get("verification_summary"),
+            verification_refs=d.get("verification_refs"),
+            original_body=d.get("original_body"),
+            original_path=d.get("original_path"),
+            original_line=d.get("original_line"),
+            original_commit_sha=d.get("original_commit_sha"),
+        )
+
+    def upsert_review_comment(
+        self, repo_full, issue_number, *, github_comment_id, body_hash, pr_number,
+        source, watcher_verdict, original_body=None, original_path=None,
+        original_line=None, original_commit_sha=None,
+    ):
+        key = f"{github_comment_id}:{body_hash}"
+        self.calls.append(("upsert", key, watcher_verdict, source))
+        existing = self.review_comments.get(key)
+        if existing is None:
+            self.review_comments[key] = {
+                "comment_key": key,
+                "github_comment_id": github_comment_id,
+                "body_hash": body_hash,
+                "pr_number": pr_number,
+                "source": source,
+                "watcher_verdict": watcher_verdict,
+                "resolution_status": "unresolved",
+                "pm_decision": None,
+                "handed_off_at": None,
+                "resolved_at": None,
+                "addressed_by_commit_sha": None,
+                "verification_summary": None,
+                "verification_refs": [],
+                "original_body": original_body,
+                "original_path": original_path,
+                "original_line": original_line,
+                "original_commit_sha": original_commit_sha,
+            }
+        else:
+            # Preserve the PM-owned resolution columns; refresh only what the
+            # watcher observes (mirrors the real ON CONFLICT clause).
+            existing.update({
+                "pr_number": pr_number,
+                "source": source,
+                "watcher_verdict": watcher_verdict,
+                "original_body": original_body,
+                "original_path": original_path,
+                "original_line": original_line,
+            })
+            if original_commit_sha is not None:
+                existing["original_commit_sha"] = original_commit_sha
+        return self._record(key)
+
+    def mark_review_comment_handed_off(self, repo_full, issue_number, comment_key):
+        self.calls.append(("handoff", comment_key))
+        d = self.review_comments[comment_key]
+        if d.get("handed_off_at") is None:
+            d["handed_off_at"] = "handed-off"
+        return self._record(comment_key)
+
+    def record_review_comment_resolution(
+        self, repo_full, issue_number, comment_key, *, resolution_status,
+        pm_decision=None, addressed_by_commit_sha=None, verification_summary=None,
+        verification_refs=None,
+    ):
+        self.calls.append(("record", comment_key, resolution_status))
+        d = self.review_comments[comment_key]
+        d.update({
+            "resolution_status": resolution_status,
+            "pm_decision": pm_decision,
+            "addressed_by_commit_sha": addressed_by_commit_sha,
+            "verification_summary": verification_summary,
+            "resolved_at": None if resolution_status == "unresolved" else "resolved",
+        })
+        if verification_refs is not None:
+            d["verification_refs"] = list(verification_refs)
+        return self._record(comment_key)
+
+    def list_review_comments(self, repo_full, issue_number):
+        self.calls.append(("list", repo_full, issue_number))
+        return [self._record(k) for k in self.review_comments]
 
 
 class TestStatusChecksGreen(unittest.TestCase):
@@ -278,17 +409,16 @@ class TestPrWatcherTransitions(unittest.TestCase):
 
     def test_first_must_fix_round_updates_then_assigns_fix(self):
         # A validated must-fix comment (validator returns valid_must_fix) drives
-        # the first fix round. The legacy must_fix_review_comments flag alone
-        # must NOT trigger fixing (it is routed through validation instead).
+        # the first fix round, recorded against the durable review_comments row.
         db = FakeDbClient([_run(pr_review_fix_rounds=0)])
-        c = ReviewComment(comment_id="c1", body="please fix", source="inline")
+        c = ReviewComment(comment_id="111", body="please fix", source="inline")
         assignments = []
 
         updated = reconcile_pr_run(
             db.runs[0],
             _reality(review_comments=(c,)),
             db,
-            assign_fix=lambda run, reality: assignments.append(
+            assign_fix=lambda run, reality, keys: assignments.append(
                 run.pr_review_fix_rounds
             ),
             validate_comment=lambda _c: "valid_must_fix",
@@ -296,14 +426,21 @@ class TestPrWatcherTransitions(unittest.TestCase):
 
         self.assertEqual(updated.phase, "fixing")
         self.assertEqual(updated.pr_review_fix_rounds, 1)
-        self.assertEqual(db.calls[0][0], "update_pr_fields")
-        self.assertTrue(db.calls[0][5])
+        upd = [x for x in db.calls if x[0] == "update_pr_fields"]
+        self.assertEqual(len(upd), 1)
+        self.assertEqual(upd[0][4], "fixing")
+        self.assertTrue(upd[0][5])  # increment_fix_rounds
         self.assertEqual(assignments, [1])
+        # The comment was persisted with the watcher verdict.
+        self.assertEqual(
+            db.review_comments[c.stable_key]["watcher_verdict"], "valid_must_fix",
+        )
 
     def test_second_must_fix_round_blocks_without_assignment(self):
-        # Round cap: a fresh validated must-fix with the budget exhausted blocks.
+        # Round cap: a still-unresolved validated must-fix with the budget
+        # exhausted blocks instead of being auto-fixed a second time.
         db = FakeDbClient([_run(pr_review_fix_rounds=1)])
-        c = ReviewComment(comment_id="c1", body="please fix", source="inline")
+        c = ReviewComment(comment_id="111", body="please fix", source="inline")
         assignments = []
 
         updated = reconcile_pr_run(
@@ -316,21 +453,25 @@ class TestPrWatcherTransitions(unittest.TestCase):
 
         self.assertEqual(updated.phase, "blocked")
         self.assertEqual(assignments, [])
-        self.assertEqual(db.calls[0][0], "blocked")
+        blocked = [x for x in db.calls if x[0] == "blocked"]
+        self.assertEqual(len(blocked), 1)
+        self.assertIn("remain after", blocked[0][3].lower())
 
     def test_green_without_must_fix_is_ready_to_merge(self):
         db = FakeDbClient([_run()])
         updated = reconcile_pr_run(db.runs[0], _reality(ci_green=True), db)
 
         self.assertEqual(updated.phase, "ready_to_merge")
-        self.assertEqual(db.calls[0][4], "ready_to_merge")
+        upd = [x for x in db.calls if x[0] == "update_pr_fields"]
+        self.assertEqual(upd[-1][4], "ready_to_merge")
 
     def test_pending_ci_keeps_watching(self):
         db = FakeDbClient([_run(phase="pr_open")])
         updated = reconcile_pr_run(db.runs[0], _reality(ci_green=False), db)
 
         self.assertEqual(updated.phase, "pr_watching")
-        self.assertEqual(db.calls[0][4], "pr_watching")
+        upd = [x for x in db.calls if x[0] == "update_pr_fields"]
+        self.assertEqual(upd[-1][4], "pr_watching")
 
     def test_check_once_fetches_pr_reality_for_listed_runs(self):
         db = FakeDbClient([_run(phase="pr_open")])
@@ -670,53 +811,6 @@ class TestDefaultValidationGate(unittest.TestCase):
         self.assertNotEqual(verdict, "valid_must_fix")
 
 
-class TestReviewCommentTriage(unittest.TestCase):
-    def _c(self, body="please fix this", cid="111"):
-        return ReviewComment(comment_id=cid, body=body, source="inline", path="a.dart", line=1)
-
-    def test_valid_must_fix_is_actionable_when_unattempted(self):
-        c = self._c()
-        t = triage_review_comments([c], {}, lambda _c: "valid_must_fix")
-        self.assertIn(c.stable_key, t.actionable_keys)
-        self.assertEqual(t.bookkeeping[c.stable_key]["verdict"], "valid_must_fix")
-        self.assertFalse(t.bookkeeping[c.stable_key]["attempted"])
-
-    def test_attempted_key_is_not_actionable_again(self):
-        c = self._c()
-        prior = {c.stable_key: {"verdict": "valid_must_fix", "attempted": True}}
-        t = triage_review_comments([c], prior, lambda _c: "valid_must_fix")
-        self.assertEqual(t.actionable_keys, [])
-        # attempted state is preserved.
-        self.assertTrue(t.bookkeeping[c.stable_key]["attempted"])
-
-    def test_changed_body_becomes_new_candidate(self):
-        c1 = self._c(body="old body")
-        prior = {c1.stable_key: {"verdict": "valid_must_fix", "attempted": True}}
-        c2 = self._c(body="new different body")  # same id, new body -> new key
-        self.assertNotEqual(c1.stable_key, c2.stable_key)
-        t = triage_review_comments([c2], prior, lambda _c: "valid_must_fix")
-        self.assertIn(c2.stable_key, t.actionable_keys)
-        self.assertFalse(t.bookkeeping[c2.stable_key]["attempted"])
-
-    def test_invalid_and_optional_are_not_actionable(self):
-        ci = self._c(body="resolved already", cid="1")
-        co = self._c(body="nit", cid="2")
-        t = triage_review_comments(
-            [ci, co], {},
-            lambda c: "invalid" if c.comment_id == "1" else "valid_optional",
-        )
-        self.assertEqual(t.actionable_keys, [])
-        self.assertEqual(t.needs_judgment_keys, [])
-        self.assertIn(ci.stable_key, t.invalid_keys)
-        self.assertIn(co.stable_key, t.optional_keys)
-
-    def test_needs_user_judgment_collected(self):
-        c = self._c()
-        t = triage_review_comments([c], {}, lambda _c: "needs_user_judgment")
-        self.assertIn(c.stable_key, t.needs_judgment_keys)
-        self.assertEqual(t.actionable_keys, [])
-
-
 class TestValidatedCommentReconcile(unittest.TestCase):
     def _inline(self, cid="111", body="please fix this", **o):
         return ReviewComment(
@@ -732,36 +826,32 @@ class TestValidatedCommentReconcile(unittest.TestCase):
             db.runs[0],
             _reality(review_comments=(c,)),
             db,
-            assign_fix=lambda run, reality: assignments.append(reality),
+            assign_fix=lambda run, reality, keys: assignments.append(reality),
             validate_comment=lambda _c: "valid_must_fix",
         )
 
         self.assertEqual(updated.phase, "fixing")
         self.assertEqual(updated.pr_review_fix_rounds, 1)
         self.assertEqual(len(assignments), 1)
-        self.assertEqual(db.calls[0][0], "update_pr_fields")
-        self.assertTrue(db.calls[0][5])  # increment_fix_rounds
-        meta = db.calls[0][-1]
-        entry = meta["pr_review_comments"][c.stable_key]
-        self.assertEqual(entry["verdict"], "valid_must_fix")
-        self.assertTrue(entry["attempted"])
+        upd = [x for x in db.calls if x[0] == "update_pr_fields"]
+        self.assertEqual(len(upd), 1)
+        self.assertTrue(upd[0][5])  # increment_fix_rounds
+        # The durable row records the watcher verdict and stays unresolved
+        # until the PM records a resolution.
+        row = db.review_comments[c.stable_key]
+        self.assertEqual(row["watcher_verdict"], "valid_must_fix")
+        self.assertEqual(row["resolution_status"], "unresolved")
 
     def test_same_comment_not_fixed_twice_and_not_ready_to_merge(self):
-        # Finding 2: a valid must-fix already attempted once and still present
-        # must NOT slip to ready_to_merge even with green CI, and must NOT get a
-        # second fix; it escalates to a human instead.
+        # A valid must-fix still unresolved after the one allowed round must NOT
+        # slip to ready_to_merge even with green CI, and must NOT be auto-fixed a
+        # second time; it escalates to a human instead.
         c = self._inline()
-        run = _run(
-            pr_review_fix_rounds=1,
-            metadata={"pr_review_comments": {
-                c.stable_key: {"verdict": "valid_must_fix", "attempted": True},
-            }},
-        )
-        db = FakeDbClient([run])
+        db = FakeDbClient([_run(pr_review_fix_rounds=1)])
         assignments = []
 
         updated = reconcile_pr_run(
-            run,
+            db.runs[0],
             _reality(review_comments=(c,), ci_green=True),
             db,
             assign_fix=lambda *a: assignments.append(a),
@@ -770,31 +860,84 @@ class TestValidatedCommentReconcile(unittest.TestCase):
 
         self.assertEqual(updated.phase, "blocked")
         self.assertEqual(assignments, [])
-        self.assertEqual(db.calls[0][0], "blocked")
-        self.assertIn("remain after", db.calls[0][3].lower())
+        blocked = [x for x in db.calls if x[0] == "blocked"]
+        self.assertEqual(len(blocked), 1)
+        self.assertIn("remain after", blocked[0][3].lower())
 
     def test_changed_body_can_be_fixed_again_as_new_candidate(self):
         old = self._inline(body="old advice")
         new = self._inline(body="new advice entirely")
-        run = _run(
-            pr_review_fix_rounds=0,
-            metadata={"pr_review_comments": {
-                old.stable_key: {"verdict": "valid_must_fix", "attempted": True},
-            }},
+        # The old body was already addressed; the edited comment has a new
+        # comment_key, so it is a fresh fix candidate.
+        db = FakeDbClient(
+            [_run(pr_review_fix_rounds=0)],
+            comments=[_seed(
+                old, watcher_verdict="valid_must_fix", resolution_status="addressed",
+                addressed_by_commit_sha="abc", verification_summary="done",
+                resolved_at="resolved",
+            )],
         )
-        db = FakeDbClient([run])
         assignments = []
 
+        self.assertNotEqual(old.stable_key, new.stable_key)
         updated = reconcile_pr_run(
-            run,
+            db.runs[0],
             _reality(review_comments=(new,)),
             db,
-            assign_fix=lambda run, reality: assignments.append(reality),
+            assign_fix=lambda run, reality, keys: assignments.append(reality),
             validate_comment=lambda _c: "valid_must_fix",
         )
 
         self.assertEqual(updated.phase, "fixing")
         self.assertEqual(len(assignments), 1)
+
+    def test_mixed_must_fix_and_judgment_assigns_only_must_fix(self):
+        # valid_must_fix + needs_user_judgment in one fetch: only the must-fix
+        # key is assigned to the fix round. The needs_user_judgment row stays
+        # unresolved and un-handed-off, so it follows its own handoff/block path
+        # on a later pass (after the must-fix resolution is recorded + re-armed).
+        must = self._inline(cid="111", body="must fix this")
+        judg = self._inline(cid="222", body="needs a product choice")
+        db = FakeDbClient([_run(pr_review_fix_rounds=0)])
+        assigned = []
+
+        first = reconcile_pr_run(
+            db.runs[0],
+            _reality(review_comments=(must, judg), ci_green=True),
+            db,
+            assign_fix=lambda run, reality, keys: assigned.append(list(keys)),
+            validate_comment=lambda c: (
+                "valid_must_fix" if c.comment_id == "111" else "needs_user_judgment"
+            ),
+        )
+
+        self.assertEqual(first.phase, "fixing")
+        self.assertEqual(assigned, [[must.stable_key]])
+        self.assertEqual(
+            db.review_comments[judg.stable_key]["resolution_status"], "unresolved",
+        )
+        self.assertIsNone(db.review_comments[judg.stable_key]["handed_off_at"])
+
+        # PM records the must-fix resolution and re-arms; the judgment comment is
+        # now the actionable one and is handed off -- it was never swept into the
+        # earlier must-fix repair prompt.
+        db.record_review_comment_resolution(
+            "o/r", 12, must.stable_key, resolution_status="addressed",
+            pm_decision="valid_must_fix", addressed_by_commit_sha="abc",
+            verification_summary="fixed; tests green",
+        )
+        handoffs = []
+        second = reconcile_pr_run(
+            _run(phase="pr_open", pr_review_fix_rounds=1),
+            _reality(review_comments=(must, judg), ci_green=True),
+            db,
+            dispatch_handoff=lambda run, reality, keys: handoffs.append(list(keys)) or True,
+            validate_comment=lambda c: (
+                "valid_must_fix" if c.comment_id == "111" else "needs_user_judgment"
+            ),
+        )
+        self.assertEqual(second.phase, "fixing")
+        self.assertEqual(handoffs, [[judg.stable_key]])
 
     def test_needs_user_judgment_blocks(self):
         db = FakeDbClient([_run()])
@@ -807,8 +950,9 @@ class TestValidatedCommentReconcile(unittest.TestCase):
         )
 
         self.assertEqual(updated.phase, "blocked")
-        self.assertEqual(db.calls[0][0], "blocked")
-        self.assertIn("user judgment", db.calls[0][3].lower())
+        blocked = [x for x in db.calls if x[0] == "blocked"]
+        self.assertEqual(len(blocked), 1)
+        self.assertIn("user judgment", blocked[0][3].lower())
 
     def test_invalid_inline_comment_does_not_block_or_fix(self):
         db = FakeDbClient([_run(pr_review_fix_rounds=0)])
@@ -822,6 +966,76 @@ class TestValidatedCommentReconcile(unittest.TestCase):
         )
 
         self.assertEqual(updated.phase, "ready_to_merge")
+
+    def test_valid_optional_does_not_block(self):
+        db = FakeDbClient([_run()])
+        c = self._inline(body="nit: rename")
+        updated = reconcile_pr_run(
+            db.runs[0],
+            _reality(review_comments=(c,), ci_green=True),
+            db,
+            validate_comment=lambda _c: "valid_optional",
+        )
+        self.assertEqual(updated.phase, "ready_to_merge")
+
+    def test_pm_addressed_resolution_does_not_block(self):
+        # The core fix: a comment the PM recorded as addressed is non-blocking on
+        # the next watcher pass, even though the watcher re-validates it as
+        # needs_user_judgment.
+        c = self._inline()
+        db = FakeDbClient(
+            [_run(phase="pr_open")],
+            comments=[_seed(
+                c, watcher_verdict="needs_user_judgment", resolution_status="addressed",
+                handed_off_at="handed-off", addressed_by_commit_sha="b6cd1ad",
+                verification_summary="guarded; tests green", resolved_at="resolved",
+            )],
+        )
+        updated = reconcile_pr_run(
+            db.runs[0],
+            _reality(review_comments=(c,), ci_green=True),
+            db,
+            validate_comment=lambda _c: "needs_user_judgment",
+        )
+        self.assertEqual(updated.phase, "ready_to_merge")
+
+    def test_pm_rejected_resolution_does_not_block(self):
+        c = self._inline()
+        db = FakeDbClient(
+            [_run(phase="pr_open")],
+            comments=[_seed(
+                c, watcher_verdict="needs_user_judgment", resolution_status="rejected",
+                handed_off_at="handed-off",
+                verification_summary="contradicts the issue spec", resolved_at="resolved",
+            )],
+        )
+        updated = reconcile_pr_run(
+            db.runs[0],
+            _reality(review_comments=(c,), ci_green=True),
+            db,
+            validate_comment=lambda _c: "needs_user_judgment",
+        )
+        self.assertEqual(updated.phase, "ready_to_merge")
+
+    def test_pm_escalated_resolution_blocks(self):
+        c = self._inline()
+        db = FakeDbClient(
+            [_run(phase="pr_open")],
+            comments=[_seed(
+                c, watcher_verdict="needs_user_judgment",
+                resolution_status="needs_user_judgment", handed_off_at="handed-off",
+                verification_summary="needs a product decision", resolved_at="resolved",
+            )],
+        )
+        updated = reconcile_pr_run(
+            db.runs[0],
+            _reality(review_comments=(c,), ci_green=True),
+            db,
+            validate_comment=lambda _c: "needs_user_judgment",
+        )
+        self.assertEqual(updated.phase, "blocked")
+        blocked = [x for x in db.calls if x[0] == "blocked"]
+        self.assertIn("user judgment", blocked[0][3].lower())
 
     def test_merged_pr_wins_over_needs_user_judgment(self):
         db = FakeDbClient([_run()])
@@ -905,8 +1119,9 @@ class TestLegacyCommentsRoutedThroughValidation(unittest.TestCase):
         updated = reconcile_pr_run(db.runs[0], reality, db)
         # Escalated for validation, never auto-fixed from marker text alone.
         self.assertEqual(updated.phase, "blocked")
-        self.assertNotEqual(db.calls[0][0], "update_pr_fields")
-        self.assertIn("user judgment", db.calls[0][3].lower())
+        self.assertNotIn("update_pr_fields", [x[0] for x in db.calls])
+        blocked = [x for x in db.calls if x[0] == "blocked"]
+        self.assertIn("user judgment", blocked[0][3].lower())
 
     def test_top_level_must_fix_comment_not_fixed_when_validator_rejects(self):
         reality = self._reality_with(
@@ -929,7 +1144,8 @@ class TestLegacyCommentsRoutedThroughValidation(unittest.TestCase):
         db = FakeDbClient([_run()])
         updated = reconcile_pr_run(db.runs[0], reality, db)
         self.assertEqual(updated.phase, "blocked")
-        self.assertIn("user judgment", db.calls[0][3].lower())
+        blocked = [x for x in db.calls if x[0] == "blocked"]
+        self.assertIn("user judgment", blocked[0][3].lower())
 
     def test_changes_requested_latest_review_escalates_not_fixes(self):
         reality = self._reality_with(
@@ -938,7 +1154,7 @@ class TestLegacyCommentsRoutedThroughValidation(unittest.TestCase):
         db = FakeDbClient([_run()])
         updated = reconcile_pr_run(db.runs[0], reality, db)
         self.assertEqual(updated.phase, "blocked")
-        self.assertNotEqual(db.calls[0][0], "update_pr_fields")
+        self.assertNotIn("update_pr_fields", [x[0] for x in db.calls])
 
     def test_changes_requested_state_validates_to_needs_user_judgment(self):
         c = ReviewComment(
@@ -952,39 +1168,6 @@ class TestLegacyCommentsRoutedThroughValidation(unittest.TestCase):
             comment_id="r1", body="", source="latest_review", state="APPROVED",
         )
         self.assertEqual(default_validate_comment(c), "valid_optional")
-
-
-class TestBookkeepingMerge(unittest.TestCase):
-    """Finding 4: prior per-comment attempted state must survive a pass that
-    sees an empty or unrelated comment list."""
-
-    def test_prior_attempted_key_preserved_when_no_current_comments(self):
-        prior = {"111:abc": {"verdict": "valid_must_fix", "attempted": True}}
-        t = triage_review_comments([], prior, lambda _c: "valid_must_fix")
-        self.assertIn("111:abc", t.bookkeeping)
-        self.assertTrue(t.bookkeeping["111:abc"]["attempted"])
-
-    def test_prior_key_preserved_alongside_unrelated_current_comment(self):
-        prior = {"111:abc": {"verdict": "valid_must_fix", "attempted": True}}
-        other = ReviewComment(comment_id="222", body="new note", source="inline")
-        t = triage_review_comments([other], prior, lambda _c: "valid_optional")
-        self.assertIn("111:abc", t.bookkeeping)
-        self.assertTrue(t.bookkeeping["111:abc"]["attempted"])
-        self.assertIn(other.stable_key, t.bookkeeping)
-
-    def test_reconcile_persists_prior_attempted_key_with_empty_comments(self):
-        prior_key = "111:abc"
-        run = _run(
-            phase="pr_open",
-            metadata={"pr_review_comments": {
-                prior_key: {"verdict": "valid_must_fix", "attempted": True},
-            }},
-        )
-        db = FakeDbClient([run])
-        reconcile_pr_run(run, _reality(review_comments=()), db)
-        meta = db.calls[0][-1]
-        self.assertIn(prior_key, meta["pr_review_comments"])
-        self.assertTrue(meta["pr_review_comments"][prior_key]["attempted"])
 
 
 class TestLiveValidationHandoff(unittest.TestCase):
@@ -1010,30 +1193,33 @@ class TestLiveValidationHandoff(unittest.TestCase):
             validate_comment=lambda _c: "needs_user_judgment",
         )
 
-        # Dispatched, parked in 'fixing', recorded handed_off, NOT blocked.
+        # Dispatched, parked in 'fixing', handed_off_at stamped in the table.
         self.assertEqual(handoffs, [[c.stable_key]])
         self.assertEqual(updated.phase, "fixing")
-        self.assertEqual(db.calls[0][0], "update_pr_fields")
-        meta = db.calls[0][-1]
-        self.assertTrue(meta["pr_review_comments"][c.stable_key]["handed_off"])
+        upd = [x for x in db.calls if x[0] == "update_pr_fields"]
+        self.assertEqual(upd[-1][4], "fixing")
+        self.assertIsNotNone(db.review_comments[c.stable_key]["handed_off_at"])
+        self.assertIn(("handoff", c.stable_key), db.calls)
+        meta = upd[-1][-1]
         self.assertIn(
             c.stable_key,
-            meta["pr_watcher"]["review_comment_triage"]["handed_off"],
+            meta["pr_watcher"]["review_comments"]["handed_off"],
         )
 
     def test_already_handed_off_key_escalates_instead_of_resending(self):
         c = self._inline()
-        run = _run(
-            phase="pr_watching",
-            metadata={"pr_review_comments": {
-                c.stable_key: {"verdict": "needs_user_judgment", "handed_off": True},
-            }},
+        # Comment was handed off on a prior pass but the PM re-armed without
+        # recording a resolution: still unresolved + handed_off_at set.
+        db = FakeDbClient(
+            [_run(phase="pr_watching")],
+            comments=[_seed(
+                c, watcher_verdict="needs_user_judgment", handed_off_at="handed-off",
+            )],
         )
-        db = FakeDbClient([run])
         handoffs = []
 
         updated = reconcile_pr_run(
-            run,
+            db.runs[0],
             _reality(review_comments=(c,)),
             db,
             dispatch_handoff=lambda *a: handoffs.append(a) or True,
@@ -1043,8 +1229,9 @@ class TestLiveValidationHandoff(unittest.TestCase):
         # Not re-sent; escalated to a human block.
         self.assertEqual(handoffs, [])
         self.assertEqual(updated.phase, "blocked")
-        self.assertEqual(db.calls[0][0], "blocked")
-        self.assertIn("user judgment", db.calls[0][3].lower())
+        blocked = [x for x in db.calls if x[0] == "blocked"]
+        self.assertEqual(len(blocked), 1)
+        self.assertIn("user judgment", blocked[0][3].lower())
 
     def test_delivery_failure_does_not_mark_handed_off(self):
         db = FakeDbClient([_run(phase="pr_watching")])
@@ -1058,10 +1245,10 @@ class TestLiveValidationHandoff(unittest.TestCase):
             validate_comment=lambda _c: "needs_user_judgment",
         )
 
-        # Keep watching and retry; handed_off must stay unset so it is re-tried.
+        # Keep watching and retry; handed_off_at stays unset so it is re-tried.
         self.assertEqual(updated.phase, "pr_watching")
-        meta = db.calls[0][-1]
-        self.assertFalse(meta["pr_review_comments"][c.stable_key]["handed_off"])
+        self.assertIsNone(db.review_comments[c.stable_key]["handed_off_at"])
+        self.assertNotIn(("handoff", c.stable_key), db.calls)
 
     def test_without_dispatcher_default_still_blocks(self):
         db = FakeDbClient([_run(phase="pr_watching")])
@@ -1141,7 +1328,7 @@ class TestLiveValidationHandoff(unittest.TestCase):
         )
         for prompt in (
             build_validation_handoff_prompt(run, reality, [c.stable_key]),
-            build_fix_prompt(run, reality),
+            build_fix_prompt(run, reality, [c.stable_key]),
         ):
             with self.subTest(prompt=prompt.splitlines()[0]):
                 self.assertIn(expected, prompt)
@@ -1248,6 +1435,166 @@ class TestPhraseSafeMarkers(unittest.TestCase):
         self.assertFalse(
             _body_is_validation_candidate("this is blocking but already addressed")
         )
+
+
+class TestHandoffPromptRecordsResolution(unittest.TestCase):
+    """The PM hand-off and fix prompts must tell the PM to record a durable
+    resolution in review_comments (via the CLI) before re-arming the watcher."""
+
+    def _comment(self):
+        return ReviewComment(
+            comment_id="3409641728", body="guard context.mounted here",
+            source="inline", path="a.dart", line=7,
+        )
+
+    def test_handoff_prompt_includes_record_command_per_key(self):
+        run = _run()
+        c = self._comment()
+        prompt = build_validation_handoff_prompt(
+            run, _reality(review_comments=(c,)), [c.stable_key],
+        )
+        self.assertIn("u_agents.record_review_comment_resolution", prompt)
+        self.assertIn("--comment-key", prompt)
+        self.assertIn(
+            record_resolution_command("o/r", 12, c.stable_key), prompt,
+        )
+
+    def test_handoff_prompt_requires_db_record_before_rearm(self):
+        run = _run()
+        c = self._comment()
+        prompt = build_validation_handoff_prompt(
+            run, _reality(review_comments=(c,)), [c.stable_key],
+        )
+        self.assertIn("BEFORE re-arming", prompt)
+        self.assertIn("review_comments table", prompt)
+        self.assertIn("addressed requires --commit-sha", prompt)
+
+    def test_fix_prompt_includes_record_command(self):
+        run = _run()
+        c = ReviewComment(comment_id="111", body="x", source="inline")
+        prompt = build_fix_prompt(run, _reality(review_comments=(c,)), [c.stable_key])
+        self.assertIn("u_agents.record_review_comment_resolution", prompt)
+        self.assertIn(
+            record_resolution_command("o/r", 12, c.stable_key), prompt,
+        )
+
+    def test_fix_prompt_lists_only_assigned_must_fix_keys(self):
+        # A needs_user_judgment comment present in the same fetch must NOT appear
+        # in the must-fix repair prompt (neither its listing nor a record
+        # command). Only the assigned must-fix key is included.
+        run = _run()
+        must = ReviewComment(comment_id="111", body="must fix this", source="inline")
+        judg = ReviewComment(comment_id="222", body="needs choice", source="inline")
+        prompt = build_fix_prompt(
+            run, _reality(review_comments=(must, judg)), [must.stable_key],
+        )
+        self.assertIn(must.stable_key, prompt)
+        self.assertNotIn(judg.stable_key, prompt)
+        self.assertIn(
+            record_resolution_command("o/r", 12, must.stable_key), prompt,
+        )
+        self.assertNotIn(
+            record_resolution_command("o/r", 12, judg.stable_key), prompt,
+        )
+
+
+class TestReArmBlackboxFlow(unittest.TestCase):
+    """End-to-end (table-backed fake): detect -> hand off -> PM records a
+    resolution -> mark_pr_open re-arm -> watcher re-decides. The durable
+    review_comments row is what carries the resolution across the re-arm."""
+
+    def _comment(self):
+        return ReviewComment(
+            comment_id="3409641728", body="guard context.mounted",
+            source="inline", path="a.dart", line=1,
+        )
+
+    def test_detect_handoff_resolve_rearm_reaches_ready_to_merge(self):
+        c = self._comment()
+        db = FakeDbClient([_run(phase="pr_watching")])
+
+        # Pass 1: watcher detects the comment and hands it off.
+        first = reconcile_pr_run(
+            db.runs[0],
+            _reality(review_comments=(c,), ci_green=True),
+            db,
+            dispatch_handoff=lambda *a: True,
+            validate_comment=lambda _c: "needs_user_judgment",
+        )
+        self.assertEqual(first.phase, "fixing")
+        self.assertIsNotNone(db.review_comments[c.stable_key]["handed_off_at"])
+
+        # PM records the resolution durably (addressed + commit + verification).
+        db.record_review_comment_resolution(
+            "o/r", 12, c.stable_key,
+            resolution_status="addressed", pm_decision="valid_must_fix",
+            addressed_by_commit_sha="b6cd1ad",
+            verification_summary="guarded with context.mounted; flutter test green",
+        )
+
+        # PM re-arms via mark_pr_open (status -> pr_open); watcher re-decides.
+        second = reconcile_pr_run(
+            _run(phase="pr_open"),
+            _reality(review_comments=(c,), ci_green=True),
+            db,
+            dispatch_handoff=lambda *a: True,
+            validate_comment=lambda _c: "needs_user_judgment",
+        )
+        self.assertEqual(second.phase, "ready_to_merge")
+
+    def test_rearm_without_recording_resolution_blocks(self):
+        c = self._comment()
+        db = FakeDbClient([_run(phase="pr_watching")])
+
+        first = reconcile_pr_run(
+            db.runs[0],
+            _reality(review_comments=(c,), ci_green=True),
+            db,
+            dispatch_handoff=lambda *a: True,
+            validate_comment=lambda _c: "needs_user_judgment",
+        )
+        self.assertEqual(first.phase, "fixing")
+
+        # PM re-arms WITHOUT recording a resolution: still unresolved + handed off.
+        second = reconcile_pr_run(
+            _run(phase="pr_open"),
+            _reality(review_comments=(c,), ci_green=True),
+            db,
+            dispatch_handoff=lambda *a: True,
+            validate_comment=lambda _c: "needs_user_judgment",
+        )
+        self.assertEqual(second.phase, "blocked")
+        blocked = [x for x in db.calls if x[0] == "blocked"]
+        self.assertIn("user judgment", blocked[-1][3].lower())
+
+    def test_rearm_with_empty_fetch_still_blocks_handed_off_unresolved(self):
+        # A later GitHub fetch returning no review comments (partial/transient,
+        # or the comment dropped from the listing) must NOT let a handed-off but
+        # unresolved comment slip to ready_to_merge. The durable table row keeps
+        # the run blocked until the PM records a resolution.
+        c = self._comment()
+        db = FakeDbClient([_run(phase="pr_watching")])
+
+        first = reconcile_pr_run(
+            db.runs[0],
+            _reality(review_comments=(c,), ci_green=True),
+            db,
+            dispatch_handoff=lambda *a: True,
+            validate_comment=lambda _c: "needs_user_judgment",
+        )
+        self.assertEqual(first.phase, "fixing")
+
+        # PM re-arms; next fetch returns NO review comments at all.
+        second = reconcile_pr_run(
+            _run(phase="pr_open"),
+            _reality(review_comments=(), ci_green=True),
+            db,
+            dispatch_handoff=lambda *a: True,
+            validate_comment=lambda _c: "needs_user_judgment",
+        )
+        self.assertEqual(second.phase, "blocked")
+        blocked = [x for x in db.calls if x[0] == "blocked"]
+        self.assertIn(c.stable_key, blocked[-1][3])
 
 
 if __name__ == "__main__":

--- a/tests/test_record_review_comment_resolution.py
+++ b/tests/test_record_review_comment_resolution.py
@@ -1,0 +1,164 @@
+import io
+import unittest
+from contextlib import redirect_stderr
+from unittest import mock
+
+from u_agents.agent_runs import ReviewCommentRecord
+from u_agents.record_review_comment_resolution import main, record_resolution
+
+
+def _record(**overrides):
+    base = dict(
+        agent_run_id="run-uuid",
+        github_comment_id=3409641728,
+        body_hash="1cf66a90f911",
+        comment_key="3409641728:1cf66a90f911",
+        pr_number=41,
+        source="inline_review",
+        watcher_verdict="needs_user_judgment",
+        resolution_status="addressed",
+        pm_decision="valid_must_fix",
+        addressed_by_commit_sha="b6cd1ad",
+        verification_summary="guarded; tests green",
+        verification_refs=[],
+    )
+    base.update(overrides)
+    return ReviewCommentRecord(**base)
+
+
+class FakeDbClient:
+    def __init__(self, record=None):
+        self.record = record or _record()
+        self.calls = []
+        self.closed = False
+
+    def record_review_comment_resolution(self, repo, issue, comment_key, **kwargs):
+        self.calls.append((repo, issue, comment_key, kwargs))
+        return self.record
+
+    def close(self):
+        self.closed = True
+
+
+class TestRecordResolution(unittest.TestCase):
+    def test_delegates_to_client(self):
+        db = FakeDbClient()
+        rec = record_resolution(
+            db, "o/r", 41, "3409641728:1cf66a90f911",
+            resolution_status="addressed", pm_decision="valid_must_fix",
+            addressed_by_commit_sha="b6cd1ad",
+            verification_summary="guarded; tests green",
+            verification_refs=["https://ci/run/1"],
+        )
+        self.assertEqual(rec.resolution_status, "addressed")
+        self.assertEqual(len(db.calls), 1)
+        repo, issue, key, kwargs = db.calls[0]
+        self.assertEqual((repo, issue, key), ("o/r", 41, "3409641728:1cf66a90f911"))
+        self.assertEqual(kwargs["resolution_status"], "addressed")
+        self.assertEqual(kwargs["addressed_by_commit_sha"], "b6cd1ad")
+        self.assertEqual(kwargs["verification_refs"], ["https://ci/run/1"])
+
+
+class TestMain(unittest.TestCase):
+    def _run_main(self, argv, db=None):
+        db = db or FakeDbClient()
+        with mock.patch(
+            "u_agents.record_review_comment_resolution.AgentRunsClient.from_env",
+            return_value=db,
+        ), redirect_stderr(io.StringIO()):
+            rc = main(argv)
+        return rc, db
+
+    def test_addressed_records_and_closes_client(self):
+        rc, db = self._run_main([
+            "--repo", "o/r", "--issue", "41",
+            "--comment-key", "3409641728:1cf66a90f911",
+            "--resolution-status", "addressed",
+            "--pm-decision", "valid_must_fix",
+            "--commit-sha", "b6cd1ad",
+            "--verification-summary", "guarded; tests green",
+        ])
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(db.calls), 1)
+        _repo, _issue, key, kwargs = db.calls[0]
+        self.assertEqual(key, "3409641728:1cf66a90f911")
+        self.assertEqual(kwargs["resolution_status"], "addressed")
+        self.assertEqual(kwargs["addressed_by_commit_sha"], "b6cd1ad")
+        self.assertTrue(db.closed)
+
+    def test_verification_ref_is_repeatable(self):
+        rc, db = self._run_main([
+            "--repo", "o/r", "--issue", "41", "--comment-key", "1:abc",
+            "--resolution-status", "rejected",
+            "--verification-summary", "contradicts spec",
+            "--verification-ref", "https://a", "--verification-ref", "https://b",
+        ])
+        self.assertEqual(rc, 0)
+        self.assertEqual(db.calls[0][3]["verification_refs"], ["https://a", "https://b"])
+
+    def test_addressed_requires_commit_sha(self):
+        with self.assertRaises(SystemExit):
+            self._run_main([
+                "--repo", "o/r", "--issue", "41", "--comment-key", "1:abc",
+                "--resolution-status", "addressed",
+                "--verification-summary", "done",
+            ])
+
+    def test_addressed_requires_verification_summary(self):
+        with self.assertRaises(SystemExit):
+            self._run_main([
+                "--repo", "o/r", "--issue", "41", "--comment-key", "1:abc",
+                "--resolution-status", "addressed", "--commit-sha", "sha",
+            ])
+
+    def test_rejected_requires_reason(self):
+        with self.assertRaises(SystemExit):
+            self._run_main([
+                "--repo", "o/r", "--issue", "41", "--comment-key", "1:abc",
+                "--resolution-status", "rejected",
+            ])
+
+    def test_needs_user_judgment_requires_reason(self):
+        with self.assertRaises(SystemExit):
+            self._run_main([
+                "--repo", "o/r", "--issue", "41", "--comment-key", "1:abc",
+                "--resolution-status", "needs_user_judgment",
+            ])
+
+    def test_invalid_request_does_not_open_db_connection(self):
+        # p.error exits before AgentRunsClient.from_env is called.
+        with mock.patch(
+            "u_agents.record_review_comment_resolution.AgentRunsClient.from_env",
+            side_effect=AssertionError("must not connect on invalid args"),
+        ), redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit):
+                main([
+                    "--repo", "o/r", "--issue", "41", "--comment-key", "1:abc",
+                    "--resolution-status", "addressed",
+                ])
+
+    def test_requires_repo_issue_key_and_status(self):
+        for argv in (
+            ["--issue", "41", "--comment-key", "1:abc", "--resolution-status", "rejected",
+             "--verification-summary", "r"],
+            ["--repo", "o/r", "--comment-key", "1:abc", "--resolution-status", "rejected",
+             "--verification-summary", "r"],
+            ["--repo", "o/r", "--issue", "41", "--resolution-status", "rejected",
+             "--verification-summary", "r"],
+            ["--repo", "o/r", "--issue", "41", "--comment-key", "1:abc",
+             "--verification-summary", "r"],
+        ):
+            with self.subTest(argv=argv):
+                with self.assertRaises(SystemExit):
+                    main(argv)
+
+    def test_unknown_resolution_status_is_rejected_by_argparse(self):
+        with self.assertRaises(SystemExit):
+            main([
+                "--repo", "o/r", "--issue", "41", "--comment-key", "1:abc",
+                "--resolution-status", "bogus",
+            ])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_record_review_comment_resolution.py
+++ b/tests/test_record_review_comment_resolution.py
@@ -152,6 +152,23 @@ class TestMain(unittest.TestCase):
                 with self.assertRaises(SystemExit):
                     main(argv)
 
+    def test_invalid_comment_key_format_rejected_before_db_connection(self):
+        # A comment key missing the 'github_comment_id:body_hash' colon shape is
+        # rejected by the pre-DB validation block (exit 2) before from_env runs.
+        with mock.patch(
+            "u_agents.record_review_comment_resolution.AgentRunsClient.from_env",
+            side_effect=AssertionError("must not connect on invalid comment key"),
+        ), redirect_stderr(io.StringIO()):
+            for bad_key in ("nocolon", ":abc", "1:", "  :  "):
+                with self.subTest(bad_key=bad_key):
+                    with self.assertRaises(SystemExit):
+                        main([
+                            "--repo", "o/r", "--issue", "41",
+                            "--comment-key", bad_key,
+                            "--resolution-status", "rejected",
+                            "--verification-summary", "reason",
+                        ])
+
     def test_unknown_resolution_status_is_rejected_by_argparse(self):
         with self.assertRaises(SystemExit):
             main([

--- a/u_agents/agent_runs.py
+++ b/u_agents/agent_runs.py
@@ -16,6 +16,9 @@ from u_agents.contract import (
 )
 from u_agents.control_plane import (
     AGENT_RUN_STATUSES,
+    REVIEW_COMMENT_RESOLUTION_STATUSES,
+    REVIEW_COMMENT_SOURCES,
+    REVIEW_COMMENT_VERDICTS,
     RunnerIdentity,
     database_url_from_env,
     load_runner_identity,
@@ -86,6 +89,59 @@ class AgentRun:
             pr_review_fix_rounds=int(row.get("pr_review_fix_rounds") or 0),
             block_reason=row.get("block_reason"),
             metadata=row.get("metadata") or {},
+        )
+
+
+@dataclass(frozen=True)
+class ReviewCommentRecord:
+    """A durable PR review comment row from ``review_comments``.
+
+    The watcher owns ``watcher_verdict`` (what it observed); the PM owns
+    ``pm_decision`` and the ``resolution_status`` lifecycle plus the commit /
+    verification evidence. ``comment_key`` (``github_comment_id:body_hash``) is
+    the stable identity used across passes and by the PM CLI.
+    """
+
+    agent_run_id: str
+    github_comment_id: int
+    body_hash: str
+    comment_key: str
+    pr_number: int
+    source: str
+    watcher_verdict: str
+    resolution_status: str
+    pm_decision: str | None = None
+    handed_off_at: Any = None
+    resolved_at: Any = None
+    addressed_by_commit_sha: str | None = None
+    verification_summary: str | None = None
+    verification_refs: Any = None
+    original_body: str | None = None
+    original_path: str | None = None
+    original_line: int | None = None
+    original_commit_sha: str | None = None
+
+    @classmethod
+    def from_row(cls, row: Mapping[str, Any]) -> "ReviewCommentRecord":
+        return cls(
+            agent_run_id=str(row["agent_run_id"]),
+            github_comment_id=int(row["github_comment_id"]),
+            body_hash=str(row["body_hash"]),
+            comment_key=str(row["comment_key"]),
+            pr_number=int(row["pr_number"]),
+            source=str(row["source"]),
+            watcher_verdict=str(row["watcher_verdict"]),
+            resolution_status=str(row["resolution_status"]),
+            pm_decision=row.get("pm_decision"),
+            handed_off_at=row.get("handed_off_at"),
+            resolved_at=row.get("resolved_at"),
+            addressed_by_commit_sha=row.get("addressed_by_commit_sha"),
+            verification_summary=row.get("verification_summary"),
+            verification_refs=row.get("verification_refs"),
+            original_body=row.get("original_body"),
+            original_path=row.get("original_path"),
+            original_line=row.get("original_line"),
+            original_commit_sha=row.get("original_commit_sha"),
         )
 
 
@@ -164,6 +220,111 @@ def validate_metadata(metadata: Mapping[str, Any] | None) -> Mapping[str, Any]:
     return metadata
 
 
+# ---------------------------------------------------------------------------
+# review_comments validation (shared by AgentRunsClient and the PM CLI)
+# ---------------------------------------------------------------------------
+
+
+def validate_github_comment_id(value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("github_comment_id must be an integer")
+    return value
+
+
+def validate_body_hash(value: str) -> str:
+    if not isinstance(value, str) or value.strip() == "":
+        raise ValueError("body_hash must be a non-empty string")
+    if any(ch.isspace() for ch in value):
+        raise ValueError("body_hash must not contain whitespace")
+    return value
+
+
+def validate_comment_key(value: str) -> str:
+    if not isinstance(value, str) or value.strip() == "":
+        raise ValueError("comment_key must be a non-empty string")
+    return value
+
+
+def validate_review_comment_source(value: str) -> str:
+    if value not in REVIEW_COMMENT_SOURCES:
+        raise ValueError(
+            f"source must be one of: {', '.join(REVIEW_COMMENT_SOURCES)}"
+        )
+    return value
+
+
+def validate_watcher_verdict(value: str) -> str:
+    if value not in REVIEW_COMMENT_VERDICTS:
+        raise ValueError(
+            f"watcher_verdict must be one of: {', '.join(REVIEW_COMMENT_VERDICTS)}"
+        )
+    return value
+
+
+def validate_pm_decision(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if value not in REVIEW_COMMENT_VERDICTS:
+        raise ValueError(
+            f"pm_decision must be one of: {', '.join(REVIEW_COMMENT_VERDICTS)}"
+        )
+    return value
+
+
+def validate_resolution_status(value: str) -> str:
+    if value not in REVIEW_COMMENT_RESOLUTION_STATUSES:
+        raise ValueError(
+            "resolution_status must be one of: "
+            + ", ".join(REVIEW_COMMENT_RESOLUTION_STATUSES)
+        )
+    return value
+
+
+def validate_verification_refs(refs: Any) -> list:
+    """Validate that verification_refs is a JSON array (list)."""
+    if refs is None:
+        return []
+    if not isinstance(refs, (list, tuple)):
+        raise ValueError("verification_refs must be a JSON array (list)")
+    json.dumps(list(refs))
+    return list(refs)
+
+
+def _is_blank(value: str | None) -> bool:
+    return value is None or str(value).strip() == ""
+
+
+def validate_review_comment_resolution(
+    resolution_status: str,
+    *,
+    addressed_by_commit_sha: str | None,
+    verification_summary: str | None,
+) -> None:
+    """Enforce the evidence each terminal resolution requires.
+
+    The DB also enforces ``addressed`` requires a commit + verification summary;
+    this gives the client and CLI an early, specific error and additionally
+    requires a reason (``verification_summary``) for ``rejected`` /
+    ``needs_user_judgment`` so a PM cannot silently close a comment.
+    """
+    validate_resolution_status(resolution_status)
+    if resolution_status == "addressed":
+        if _is_blank(addressed_by_commit_sha):
+            raise ValueError(
+                "resolution_status 'addressed' requires addressed_by_commit_sha"
+            )
+        if _is_blank(verification_summary):
+            raise ValueError(
+                "resolution_status 'addressed' requires verification_summary"
+            )
+    elif resolution_status in ("rejected", "needs_user_judgment"):
+        if _is_blank(verification_summary):
+            raise ValueError(
+                f"resolution_status '{resolution_status}' requires a reason in "
+                "verification_summary"
+            )
+
+
 def build_claim_payload(
     repo: RepoConfig,
     issue_number: int,
@@ -201,6 +362,35 @@ def _row_columns() -> str:
         "worktree_basename, tmux_window, pm_pane, pr_number, "
         "pr_review_fix_rounds, block_reason, metadata"
     )
+
+
+_REVIEW_COMMENT_COLUMNS = (
+    "agent_run_id",
+    "github_comment_id",
+    "body_hash",
+    "comment_key",
+    "pr_number",
+    "source",
+    "watcher_verdict",
+    "pm_decision",
+    "resolution_status",
+    "original_body",
+    "original_path",
+    "original_line",
+    "original_commit_sha",
+    "handed_off_at",
+    "resolved_at",
+    "addressed_by_commit_sha",
+    "verification_summary",
+    "verification_refs",
+    "first_seen_at",
+    "last_seen_at",
+)
+
+
+def _review_comment_columns(prefix: str = "") -> str:
+    dot = f"{prefix}." if prefix else ""
+    return ", ".join(f"{dot}{c}" for c in _REVIEW_COMMENT_COLUMNS)
 
 
 class AgentRunsClient:
@@ -570,6 +760,215 @@ class AgentRunsClient:
             ORDER BY updated_at ASC
         """
         return [AgentRun.from_row(r) for r in self._fetch_all(sql, {})]
+
+    # ----- review_comments -------------------------------------------------
+
+    def upsert_review_comment(
+        self,
+        repository_full_name: str,
+        github_issue_number: int,
+        *,
+        github_comment_id: int,
+        body_hash: str,
+        pr_number: int,
+        source: str,
+        watcher_verdict: str,
+        original_body: str | None = None,
+        original_path: str | None = None,
+        original_line: int | None = None,
+        original_commit_sha: str | None = None,
+    ) -> ReviewCommentRecord:
+        """Record a review comment the watcher saw this pass.
+
+        First detection inserts the row; later passes update only the
+        watcher-observed fields (``watcher_verdict``, ``source``, ``pr_number``,
+        the captured original_* fields) and ``last_seen_at``. The PM-owned
+        resolution lifecycle (``pm_decision``, ``resolution_status``,
+        ``handed_off_at``, ``resolved_at``, commit, verification) is preserved
+        across passes so an addressed/rejected comment is never silently reset
+        to ``unresolved`` by a later watcher observation.
+        """
+        validate_repository_full_name(repository_full_name)
+        validate_issue_number(github_issue_number)
+        validate_github_comment_id(github_comment_id)
+        validate_body_hash(body_hash)
+        if not isinstance(pr_number, int) or isinstance(pr_number, bool) or pr_number <= 0:
+            raise ValueError("pr_number must be a positive integer")
+        validate_review_comment_source(source)
+        validate_watcher_verdict(watcher_verdict)
+        sql = f"""
+            INSERT INTO review_comments (
+                agent_run_id, github_comment_id, body_hash, pr_number, source,
+                watcher_verdict, original_body, original_path, original_line,
+                original_commit_sha, last_seen_at
+            )
+            SELECT run_id, %(github_comment_id)s, %(body_hash)s, %(pr_number)s,
+                   %(source)s, %(watcher_verdict)s, %(original_body)s,
+                   %(original_path)s, %(original_line)s, %(original_commit_sha)s,
+                   now()
+            FROM agent_runs
+            WHERE repository_full_name = %(repository_full_name)s
+              AND github_issue_number = %(github_issue_number)s
+            ON CONFLICT ON CONSTRAINT review_comments_pkey DO UPDATE
+            SET pr_number = EXCLUDED.pr_number,
+                source = EXCLUDED.source,
+                watcher_verdict = EXCLUDED.watcher_verdict,
+                original_body = EXCLUDED.original_body,
+                original_path = EXCLUDED.original_path,
+                original_line = EXCLUDED.original_line,
+                original_commit_sha = COALESCE(
+                    EXCLUDED.original_commit_sha,
+                    review_comments.original_commit_sha
+                ),
+                last_seen_at = now()
+            RETURNING {_review_comment_columns()}
+        """
+        row = self._fetch_one(sql, {
+            "repository_full_name": repository_full_name,
+            "github_issue_number": github_issue_number,
+            "github_comment_id": github_comment_id,
+            "body_hash": body_hash,
+            "pr_number": pr_number,
+            "source": source,
+            "watcher_verdict": watcher_verdict,
+            "original_body": original_body,
+            "original_path": original_path,
+            "original_line": original_line,
+            "original_commit_sha": original_commit_sha,
+        })
+        if row is None:
+            raise RuntimeError(
+                "agent_runs row not found for review comment upsert: "
+                f"{repository_full_name}#{github_issue_number}"
+            )
+        return ReviewCommentRecord.from_row(row)
+
+    def mark_review_comment_handed_off(
+        self,
+        repository_full_name: str,
+        github_issue_number: int,
+        comment_key: str,
+    ) -> ReviewCommentRecord:
+        """Stamp ``handed_off_at`` the first time a comment is sent to the PM.
+
+        Idempotent: the original hand-off timestamp is preserved so a later call
+        does not look like a fresh hand-off.
+        """
+        validate_repository_full_name(repository_full_name)
+        validate_issue_number(github_issue_number)
+        validate_comment_key(comment_key)
+        sql = f"""
+            UPDATE review_comments AS rc
+            SET handed_off_at = COALESCE(rc.handed_off_at, now())
+            FROM agent_runs AS ar
+            WHERE rc.agent_run_id = ar.run_id
+              AND ar.repository_full_name = %(repository_full_name)s
+              AND ar.github_issue_number = %(github_issue_number)s
+              AND rc.comment_key = %(comment_key)s
+            RETURNING {_review_comment_columns("rc")}
+        """
+        row = self._fetch_one(sql, {
+            "repository_full_name": repository_full_name,
+            "github_issue_number": github_issue_number,
+            "comment_key": comment_key,
+        })
+        if row is None:
+            raise RuntimeError(
+                f"review_comments row {comment_key!r} not found for "
+                f"{repository_full_name}#{github_issue_number}"
+            )
+        return ReviewCommentRecord.from_row(row)
+
+    def record_review_comment_resolution(
+        self,
+        repository_full_name: str,
+        github_issue_number: int,
+        comment_key: str,
+        *,
+        resolution_status: str,
+        pm_decision: str | None = None,
+        addressed_by_commit_sha: str | None = None,
+        verification_summary: str | None = None,
+        verification_refs: Any = None,
+    ) -> ReviewCommentRecord:
+        """Persist the PM's decision for one review comment.
+
+        ``addressed`` requires a commit sha and a verification summary;
+        ``rejected`` / ``needs_user_judgment`` require a reason in
+        ``verification_summary``. ``resolved_at`` is set for any terminal status
+        and cleared for ``unresolved`` (the DB enforces the same invariants).
+        """
+        validate_repository_full_name(repository_full_name)
+        validate_issue_number(github_issue_number)
+        validate_comment_key(comment_key)
+        validate_pm_decision(pm_decision)
+        refs = validate_verification_refs(verification_refs)
+        validate_review_comment_resolution(
+            resolution_status,
+            addressed_by_commit_sha=addressed_by_commit_sha,
+            verification_summary=verification_summary,
+        )
+        sql = f"""
+            UPDATE review_comments AS rc
+            SET pm_decision = %(pm_decision)s,
+                resolution_status = %(resolution_status)s,
+                addressed_by_commit_sha = %(addressed_by_commit_sha)s,
+                verification_summary = %(verification_summary)s,
+                verification_refs = COALESCE(
+                    %(verification_refs)s::jsonb, rc.verification_refs
+                ),
+                resolved_at = CASE
+                    WHEN %(resolution_status)s = 'unresolved' THEN NULL
+                    ELSE now()
+                END
+            FROM agent_runs AS ar
+            WHERE rc.agent_run_id = ar.run_id
+              AND ar.repository_full_name = %(repository_full_name)s
+              AND ar.github_issue_number = %(github_issue_number)s
+              AND rc.comment_key = %(comment_key)s
+            RETURNING {_review_comment_columns("rc")}
+        """
+        row = self._fetch_one(sql, {
+            "repository_full_name": repository_full_name,
+            "github_issue_number": github_issue_number,
+            "comment_key": comment_key,
+            "pm_decision": pm_decision,
+            "resolution_status": resolution_status,
+            "addressed_by_commit_sha": addressed_by_commit_sha,
+            "verification_summary": verification_summary,
+            "verification_refs": (
+                json.dumps(refs) if verification_refs is not None else None
+            ),
+        })
+        if row is None:
+            raise RuntimeError(
+                f"review_comments row {comment_key!r} not found for "
+                f"{repository_full_name}#{github_issue_number}"
+            )
+        return ReviewCommentRecord.from_row(row)
+
+    def list_review_comments(
+        self,
+        repository_full_name: str,
+        github_issue_number: int,
+    ) -> list[ReviewCommentRecord]:
+        validate_repository_full_name(repository_full_name)
+        validate_issue_number(github_issue_number)
+        sql = f"""
+            SELECT {_review_comment_columns("rc")}
+            FROM review_comments AS rc
+            JOIN agent_runs AS ar ON ar.run_id = rc.agent_run_id
+            WHERE ar.repository_full_name = %(repository_full_name)s
+              AND ar.github_issue_number = %(github_issue_number)s
+            ORDER BY rc.first_seen_at ASC
+        """
+        return [
+            ReviewCommentRecord.from_row(r)
+            for r in self._fetch_all(sql, {
+                "repository_full_name": repository_full_name,
+                "github_issue_number": github_issue_number,
+            })
+        ]
 
     def _validate_claim_payload(self, payload: ClaimPayload) -> None:
         validate_repository_full_name(payload.repository_full_name)

--- a/u_agents/agent_runs.py
+++ b/u_agents/agent_runs.py
@@ -242,6 +242,15 @@ def validate_body_hash(value: str) -> str:
 def validate_comment_key(value: str) -> str:
     if not isinstance(value, str) or value.strip() == "":
         raise ValueError("comment_key must be a non-empty string")
+    # comment_key is the ``github_comment_id:body_hash`` generated column. The
+    # id part may be a signed 64-bit integer (synthetic review signals use
+    # deterministic signed ids), so only enforce the colon-delimited shape with
+    # non-empty parts rather than the exact id/hash formats.
+    head, sep, tail = value.partition(":")
+    if not sep or head.strip() == "" or tail.strip() == "":
+        raise ValueError(
+            "comment_key must be 'github_comment_id:body_hash' with non-empty parts"
+        )
     return value
 
 
@@ -286,7 +295,12 @@ def validate_verification_refs(refs: Any) -> list:
         return []
     if not isinstance(refs, (list, tuple)):
         raise ValueError("verification_refs must be a JSON array (list)")
-    json.dumps(list(refs))
+    try:
+        json.dumps(list(refs))
+    except TypeError as e:
+        raise ValueError(
+            "verification_refs elements must be JSON-serializable"
+        ) from e
     return list(refs)
 
 

--- a/u_agents/control_plane.py
+++ b/u_agents/control_plane.py
@@ -40,6 +40,32 @@ RUN_PHASE_STATUSES = (
     "cancelled",
 )
 
+# review_comments contract (see u_agents/db/003_review_comments.sql). These are
+# the single Python-side source for the SQL CHECK enums so the DB, the runtime
+# client, the PR watcher, and the PM CLI cannot drift apart.
+REVIEW_COMMENT_SOURCES = (
+    "top_level",
+    "review_body",
+    "inline_review",
+    "unknown",
+)
+# Verdict the watcher records about a comment (what it observed). Also the set
+# of values the PM may record as `pm_decision`.
+REVIEW_COMMENT_VERDICTS = (
+    "valid_must_fix",
+    "valid_optional",
+    "invalid",
+    "needs_user_judgment",
+)
+# Durable resolution lifecycle the PM owns. `unresolved` is the initial state;
+# `addressed`/`rejected`/`needs_user_judgment` are terminal PM decisions.
+REVIEW_COMMENT_RESOLUTION_STATUSES = (
+    "unresolved",
+    "addressed",
+    "rejected",
+    "needs_user_judgment",
+)
+
 PR_REVIEW_FIX_MAX_ROUNDS = 1
 ENV_DATABASE_URL = "U_AGENTS_DATABASE_URL"
 ENV_RUNNER_ID = "U_AGENTS_RUNNER_ID"

--- a/u_agents/db/003_review_comments.sql
+++ b/u_agents/db/003_review_comments.sql
@@ -1,0 +1,143 @@
+-- Durable per-comment PR review state.
+--
+-- `metadata.pr_review_comments` (JSONB on agent_runs) is no longer the source of
+-- truth for PR review comment workflow state: shallow JSONB merges from multiple
+-- writers corrupt shared top-level keys, and DB constraints (e.g. "addressed
+-- requires a commit + verification summary") cannot be enforced on it. PR review
+-- comment state therefore lives in this normalized table instead. The watcher
+-- records what it observed (`watcher_verdict`); the PM records the resolution
+-- (`pm_decision`, `resolution_status`, commit, verification). `mark_pr_open`
+-- only re-arms the watcher and must not touch review comment resolution.
+
+CREATE TABLE IF NOT EXISTS public.review_comments (
+    agent_run_id uuid NOT NULL
+        REFERENCES public.agent_runs(run_id)
+        ON DELETE CASCADE,
+
+    github_comment_id int8 NOT NULL,
+    body_hash text NOT NULL,
+    comment_key text GENERATED ALWAYS AS (
+        github_comment_id::text || ':' || body_hash
+    ) STORED,
+
+    pr_number int4 NOT NULL,
+    source text NOT NULL DEFAULT 'unknown',
+
+    watcher_verdict text NOT NULL,
+    pm_decision text NULL,
+    resolution_status text NOT NULL DEFAULT 'unresolved',
+
+    original_body text NULL,
+    original_path text NULL,
+    original_line int4 NULL,
+    original_commit_sha text NULL,
+
+    handed_off_at timestamptz NULL,
+    resolved_at timestamptz NULL,
+    addressed_by_commit_sha text NULL,
+
+    verification_summary text NULL,
+    verification_refs jsonb DEFAULT '[]'::jsonb NOT NULL,
+
+    first_seen_at timestamptz DEFAULT now() NOT NULL,
+    last_seen_at timestamptz DEFAULT now() NOT NULL,
+    created_at timestamptz DEFAULT now() NOT NULL,
+    updated_at timestamptz DEFAULT now() NOT NULL,
+
+    CONSTRAINT review_comments_pkey
+        PRIMARY KEY (agent_run_id, comment_key),
+
+    CONSTRAINT review_comments_pr_number_check
+        CHECK (pr_number > 0),
+
+    CONSTRAINT review_comments_body_hash_check
+        CHECK (btrim(body_hash) <> ''),
+
+    CONSTRAINT review_comments_source_check
+        CHECK (source = ANY (ARRAY[
+            'top_level',
+            'review_body',
+            'inline_review',
+            'unknown'
+        ])),
+
+    CONSTRAINT review_comments_watcher_verdict_check
+        CHECK (watcher_verdict = ANY (ARRAY[
+            'valid_must_fix',
+            'valid_optional',
+            'invalid',
+            'needs_user_judgment'
+        ])),
+
+    CONSTRAINT review_comments_pm_decision_check
+        CHECK (
+            pm_decision IS NULL OR
+            pm_decision = ANY (ARRAY[
+                'valid_must_fix',
+                'valid_optional',
+                'invalid',
+                'needs_user_judgment'
+            ])
+        ),
+
+    CONSTRAINT review_comments_resolution_status_check
+        CHECK (resolution_status = ANY (ARRAY[
+            'unresolved',
+            'addressed',
+            'rejected',
+            'needs_user_judgment'
+        ])),
+
+    CONSTRAINT review_comments_verification_refs_array_check
+        CHECK (jsonb_typeof(verification_refs) = 'array'),
+
+    CONSTRAINT review_comments_resolved_at_check
+        CHECK (
+            (resolution_status = 'unresolved' AND resolved_at IS NULL)
+            OR
+            (resolution_status <> 'unresolved' AND resolved_at IS NOT NULL)
+        ),
+
+    CONSTRAINT review_comments_addressed_requires_commit_check
+        CHECK (
+            resolution_status <> 'addressed'
+            OR (
+                addressed_by_commit_sha IS NOT NULL
+                AND btrim(addressed_by_commit_sha) <> ''
+            )
+        ),
+
+    CONSTRAINT review_comments_addressed_requires_verification_check
+        CHECK (
+            resolution_status <> 'addressed'
+            OR (
+                verification_summary IS NOT NULL
+                AND btrim(verification_summary) <> ''
+            )
+        ),
+
+    CONSTRAINT review_comments_terminal_reason_check
+        CHECK (
+            resolution_status NOT IN ('rejected', 'needs_user_judgment')
+            OR (
+                verification_summary IS NOT NULL
+                AND btrim(verification_summary) <> ''
+            )
+        )
+);
+
+CREATE INDEX IF NOT EXISTS review_comments_run_resolution_idx
+    ON public.review_comments (agent_run_id, resolution_status);
+
+CREATE INDEX IF NOT EXISTS review_comments_pr_idx
+    ON public.review_comments (pr_number);
+
+CREATE INDEX IF NOT EXISTS review_comments_last_seen_idx
+    ON public.review_comments (last_seen_at);
+
+DROP TRIGGER IF EXISTS review_comments_set_updated_at ON public.review_comments;
+
+CREATE TRIGGER review_comments_set_updated_at
+BEFORE UPDATE ON public.review_comments
+FOR EACH ROW
+EXECUTE FUNCTION set_agent_runs_updated_at();

--- a/u_agents/db/README.md
+++ b/u_agents/db/README.md
@@ -122,6 +122,88 @@ a durable reference, for example issue/PR comments, CI logs, or
 `tmp/review-result.json`. Long command output, screenshots, and full review
 bodies belong outside the DB.
 
+## Table: review_comments
+
+PR review comment workflow state is a normalized table, not
+`metadata.pr_review_comments`. JSONB shallow merges from multiple writers
+corrupt shared top-level keys, and DB constraints (e.g. "addressed requires a
+commit and a verification summary") cannot be enforced on free-form JSON. The
+watcher records what it observed (`watcher_verdict`); the PM records the durable
+resolution (`pm_decision`, `resolution_status`, commit, verification). A verdict
+written only into a GitHub PR/issue comment is NOT durable state and is ignored
+by the watcher.
+
+| Column | Type | Writer | Meaning |
+| ------ | ---- | ------ | ------- |
+| `agent_run_id` | `uuid` | watcher | Parent `agent_runs.run_id`; cascades on parent delete. |
+| `github_comment_id` | `int8` | watcher | GitHub review comment id (a derived stable id for synthetic top-level/review signals). |
+| `body_hash` | `text` | watcher | Hash of the comment body; a changed body yields a new identity. |
+| `comment_key` | `text` | DB generated | `github_comment_id:body_hash`, the stable identity used by the watcher, the hand-off prompt, and the PM CLI. |
+| `pr_number` | `int4` | watcher | PR the comment belongs to. Must be positive. |
+| `source` | `text` | watcher | `top_level`, `review_body`, `inline_review`, or `unknown`. |
+| `watcher_verdict` | `text` | watcher | `valid_must_fix`, `valid_optional`, `invalid`, or `needs_user_judgment`. |
+| `pm_decision` | `text` | PM | Optional PM verdict; same value set as `watcher_verdict`. |
+| `resolution_status` | `text` | PM | `unresolved` (initial), `addressed`, `rejected`, or `needs_user_judgment`. |
+| `handed_off_at` | `timestamptz` | watcher | Set the first time the comment is handed to the PM. |
+| `resolved_at` | `timestamptz` | PM | Set for any non-`unresolved` status; null while `unresolved`. |
+| `addressed_by_commit_sha` | `text` | PM | Required when `resolution_status = 'addressed'`. |
+| `verification_summary` | `text` | PM | Required for `addressed`, and as the reason for `rejected`/`needs_user_judgment`. |
+| `verification_refs` | `jsonb` | PM | JSON array of durable evidence pointers. |
+| `first_seen_at` / `last_seen_at` | `timestamptz` | watcher | First and most recent observation of the comment. |
+| `created_at` / `updated_at` | `timestamptz` | DB default/trigger | Row create / last update time. |
+
+`(agent_run_id, comment_key)` is the primary key. The DB enforces that
+`addressed` rows have both a non-empty `addressed_by_commit_sha` and a non-empty
+`verification_summary`, that `resolved_at` is null exactly when `resolution_status`
+is `unresolved`, and that `verification_refs` is a JSON array.
+
+### State ownership
+
+- watcher: detects GitHub review comments, upserts each into `review_comments`
+  with its `watcher_verdict`, stamps `handed_off_at` on first hand-off, and
+  decides the run's `ready_to_merge` / `blocked` / `fixing` status.
+- PM: validates handed-off comments, records `pm_decision`, and sets
+  `resolution_status` — `addressed` with the commit sha and verification
+  summary when fixed, `rejected` with a reason, or `needs_user_judgment` only
+  when a human must decide. The PM records the resolution **before** re-arming
+  the watcher.
+- `mark_pr_open`: only re-arms the PR watcher. It must not write any review
+  comment resolution.
+
+### PM CLI
+
+The PM records a resolution from the issue worktree (explicit `PYTHONPATH` and a
+psycopg-enabled interpreter, like `mark_pr_open`):
+
+```sh
+PYTHONPATH=/path/to/dotfiles /path/to/python -m u_agents.record_review_comment_resolution \
+    --repo owner/name --issue 32 --comment-key 3409641728:1cf66a90f911 \
+    --resolution-status addressed --pm-decision valid_must_fix \
+    --commit-sha b6cd1ad --verification-summary "guarded with context.mounted; flutter test green"
+```
+
+### Watcher decision contract
+
+On each pass the watcher upserts every detected comment, re-reads the table, and
+decides per comment from `resolution_status` (and `watcher_verdict` /
+`handed_off_at`):
+
+- `resolution_status = 'addressed'` does not block.
+- `resolution_status = 'rejected'` does not block.
+- `resolution_status = 'needs_user_judgment'` blocks (a human must decide).
+- `resolution_status = 'unresolved'` and `handed_off_at IS NULL` is handed off
+  to the PM.
+- `resolution_status = 'unresolved'` and `handed_off_at IS NOT NULL` blocks (the
+  PM was asked but recorded no resolution before re-arming).
+- a `watcher_verdict = 'valid_must_fix'` that is still `unresolved` follows the
+  existing `pr_review_fix_rounds` budget: one auto-fix round, then `blocked`.
+
+`valid_optional` / `invalid` comments are non-actionable and never block. The
+upsert preserves the PM-owned resolution columns across passes, so an addressed
+or rejected comment is never reset to `unresolved` by a later watcher
+observation — this is what lets a re-armed PR reach `ready_to_merge` instead of
+re-blocking on an already-handled comment.
+
 ## Status contract
 
 Allowed `agent_runs.status` values are:
@@ -160,19 +242,23 @@ Automated PR review comment fixes are allowed at most once, and only after a
 comment has been validated.
 
 1. If the PR is merged, set `status = 'done'`.
-2. If there is a fresh validated must-fix comment and `pr_review_fix_rounds = 0`,
-   set `status = 'fixing'`, increment `pr_review_fix_rounds`, mark that comment
-   attempted, and assign the engineer the must-fix list.
-3. If a validated must-fix comment was already attempted once but is still
-   present, set `status = 'blocked'` (it cannot be auto-fixed again and must not
-   be ignored).
-4. If any collected comment is classified `needs_user_judgment`:
-   - in the production `pr_watcher` CLI path, fresh keys are handed to the
-     existing PM pane for validation, marked `handed_off`, and parked in
-     `status = 'fixing'` until the PM re-arms the watcher with `mark_pr_open`;
-   - with no live dispatcher, or if the same ambiguous key is already
-     `handed_off`, set `status = 'blocked'` so a human decides (no repeat
-     auto-handoff).
+2. If there is a fresh validated must-fix comment (`watcher_verdict =
+   'valid_must_fix'`, still `resolution_status = 'unresolved'`) and
+   `pr_review_fix_rounds = 0`, set `status = 'fixing'`, increment
+   `pr_review_fix_rounds`, and assign the engineer the must-fix list.
+3. If such a must-fix comment is still `unresolved` after the one allowed round,
+   set `status = 'blocked'` (it cannot be auto-fixed again and must not be
+   ignored).
+4. If any comment needs a human decision:
+   - a fresh `needs_user_judgment` comment (`handed_off_at IS NULL`) is handed to
+     the existing PM pane for validation and parked in `status = 'fixing'` until
+     the PM records a resolution in `review_comments` and re-arms the watcher
+     with `mark_pr_open`;
+   - a comment the PM escalated (`resolution_status = 'needs_user_judgment'`), or
+     one handed off but re-armed with no recorded resolution (`unresolved` and
+     `handed_off_at IS NOT NULL`), sets `status = 'blocked'` so a human decides
+     (no repeat auto-handoff). With no live dispatcher, a fresh
+     `needs_user_judgment` comment also blocks.
 5. If there is a fresh validated must-fix comment and
    `pr_review_fix_rounds >= 1`, set `status = 'blocked'` (global round cap).
 6. If CI is green and there are no actionable/unresolved/judgment comments, set
@@ -211,20 +297,22 @@ unless it is clearly invalid:
 - When unsure between `valid_must_fix` and `valid_optional`, choose
   `valid_must_fix`. Not being fully certain is not a reason to skip a comment.
 
-### Per-comment at-most-once bookkeeping
+### Per-comment durable state
 
-`metadata.pr_review_comments` maps a stable comment identity (GitHub review
-comment id + a body hash) to `{verdict, attempted, handed_off, ...}`, merged
-forward across passes so prior `attempted` / `handed_off` state is never lost
-when a fetch returns fewer/no comments. A `valid_must_fix` comment triggers one
-automated fix attempt and is then marked `attempted`; the same id+hash on later
-passes is not auto-fixed again (and if still present it escalates to `blocked`
-rather than being ignored). A `needs_user_judgment` comment is handed off to the
-PM pane at most once via `handed_off`; after the PM re-arms the watcher with
-`mark_pr_open`, the same still-ambiguous key blocks instead of being re-sent. A
-changed body yields a new key, so an edited comment is treated as a fresh
-validation candidate. This per-comment cap is enforced in addition to the global
-`pr_review_fix_rounds` one-round cap.
+Per-comment state lives in the `review_comments` table (see above), keyed by
+`comment_key` (`github_comment_id:body_hash`), not in `metadata.pr_review_comments`.
+The watcher upserts each detected comment every pass, preserving the PM-owned
+resolution columns, so prior `resolution_status` / `handed_off_at` state is never
+lost when a fetch returns fewer/no comments. A `valid_must_fix` comment triggers
+one automated fix round (capped globally by `pr_review_fix_rounds`); if it is
+still `unresolved` afterward it escalates to `blocked` rather than being ignored.
+A `needs_user_judgment` comment is handed off to the PM pane at most once
+(`handed_off_at`); after the PM re-arms the watcher with `mark_pr_open`, the same
+still-`unresolved` key blocks instead of being re-sent. A changed body yields a
+new `comment_key`, so an edited comment is treated as a fresh validation
+candidate. `metadata.pr_review_comments` is no longer the source of truth; the
+watcher reads the table, and the PM CLI (not a GitHub comment body) is how a
+resolution becomes durable.
 
 The PR watcher never merges a PR. `ready_to_merge` is a notification state for
 the user/operator after GitHub PR existence, head branch, CI, and validated

--- a/u_agents/pr_watcher.py
+++ b/u_agents/pr_watcher.py
@@ -8,24 +8,32 @@ import json
 import shlex
 import subprocess
 import sys
-from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
 from u_agents.agent_runs import AgentRun, AgentRunsClient
 from u_agents.contract import pm_pane_target
-from u_agents.control_plane import decide_pr_watch_phase
+from u_agents.control_plane import REVIEW_COMMENT_VERDICTS, decide_pr_watch_phase
 
 
 # Verdicts produced by the validation gate. Only ``valid_must_fix`` is eligible
 # for an automated fix attempt, and only once per stable comment identity.
-REVIEW_VERDICTS = (
-    "valid_must_fix",
-    "valid_optional",
-    "invalid",
-    "needs_user_judgment",
-)
+REVIEW_VERDICTS = REVIEW_COMMENT_VERDICTS
+
+# Maps a watcher ``ReviewComment.source`` to the ``review_comments.source`` enum
+# (see u_agents/db/003_review_comments.sql). Anything unknown is persisted as
+# ``unknown`` rather than dropped.
+_DB_SOURCE = {
+    "inline": "inline_review",
+    "comment": "top_level",
+    "latest_review": "review_body",
+    "review_decision": "unknown",
+}
+
+
+def db_source(source: str) -> str:
+    return _DB_SOURCE.get(source, "unknown")
 
 
 @dataclass(frozen=True)
@@ -36,6 +44,9 @@ class ReviewComment:
     (top-level PR comment), or ``latest_review`` (a review summary). The stable
     key is the GitHub comment id plus a body hash, so a re-posted identical
     comment maps to the same key while an edited body becomes a new candidate.
+    The key matches the ``review_comments.comment_key`` generated column, so the
+    watcher, the PM hand-off prompt, and the PM CLI all reference the same
+    identity.
     """
 
     comment_id: str
@@ -48,12 +59,30 @@ class ReviewComment:
     state: str = ""
 
     @property
+    def github_comment_id(self) -> int:
+        """Stable signed-64-bit comment id for the durable table.
+
+        Inline review comments expose a numeric GitHub REST id directly. The
+        synthetic top-level / review-summary / reviewDecision keys are not
+        numeric, so derive a deterministic signed 64-bit id from the key string
+        (``review_comments.github_comment_id`` is ``int8``). Identical comment
+        ids map to identical derived ids across passes.
+        """
+        try:
+            return int(self.comment_id)
+        except (TypeError, ValueError):
+            digest = hashlib.sha256(
+                str(self.comment_id).encode("utf-8", "replace")
+            ).digest()
+            return int.from_bytes(digest[:8], "big", signed=True)
+
+    @property
     def body_hash(self) -> str:
         return hashlib.sha256(self.body.encode("utf-8", "replace")).hexdigest()
 
     @property
     def stable_key(self) -> str:
-        return f"{self.comment_id}:{self.body_hash[:12]}"
+        return f"{self.github_comment_id}:{self.body_hash[:12]}"
 
 
 @dataclass(frozen=True)
@@ -274,87 +303,6 @@ def default_validate_comment(comment: ReviewComment) -> str:
     # text) or silently treating it as optional (plain comments). Not being
     # certain is not a reason to skip a comment.
     return "needs_user_judgment"
-
-
-@dataclass(frozen=True)
-class CommentTriage:
-    bookkeeping: dict
-    actionable_keys: list
-    needs_judgment_keys: list
-    # valid_must_fix comments still present this pass that were already attempted
-    # once: not auto-fixed again, but not silently ignored either.
-    unresolved_keys: list = field(default_factory=list)
-    invalid_keys: list = field(default_factory=list)
-    optional_keys: list = field(default_factory=list)
-
-
-def triage_review_comments(
-    comments,
-    prior_bookkeeping,
-    validate: Callable[[ReviewComment], str] = default_validate_comment,
-) -> CommentTriage:
-    """Run review comments through the validation gate with at-most-once memory.
-
-    ``prior_bookkeeping`` is the persisted per-comment state keyed by
-    ``ReviewComment.stable_key`` (id + body hash). A ``valid_must_fix`` comment
-    is only ``actionable`` if it has not already been attempted under the same
-    key; if it was attempted and is still present it is reported as
-    ``unresolved`` instead (do not auto-fix again, but do not ignore it). An
-    edited body produces a new key, so it is treated as a fresh candidate.
-
-    Prior bookkeeping is merged forward, not replaced: a pass that sees an
-    empty or partial comment list must not drop previously recorded
-    verdict/attempted state, or the at-most-once guarantee would weaken.
-    """
-    if not isinstance(prior_bookkeeping, Mapping):
-        prior_bookkeeping = {}
-    # Start from prior state so historical (esp. attempted) keys survive even
-    # when the current fetch returns fewer/no comments.
-    bookkeeping: dict = {
-        k: dict(v) for k, v in prior_bookkeeping.items() if isinstance(v, Mapping)
-    }
-    actionable: list = []
-    needs_judgment: list = []
-    unresolved: list = []
-    invalid_keys: list = []
-    optional_keys: list = []
-    for comment in comments:
-        key = comment.stable_key
-        verdict = validate(comment)
-        if verdict not in REVIEW_VERDICTS:
-            verdict = "needs_user_judgment"
-        prior = prior_bookkeeping.get(key)
-        attempted = bool(prior.get("attempted")) if isinstance(prior, Mapping) else False
-        handed_off = bool(prior.get("handed_off")) if isinstance(prior, Mapping) else False
-        bookkeeping[key] = {
-            "verdict": verdict,
-            "attempted": attempted,
-            "handed_off": handed_off,
-            "comment_id": comment.comment_id,
-            "body_hash": comment.body_hash[:12],
-            "source": comment.source,
-            "path": comment.path,
-            "line": comment.line,
-        }
-        if verdict == "valid_must_fix":
-            if attempted:
-                unresolved.append(key)
-            else:
-                actionable.append(key)
-        elif verdict == "needs_user_judgment":
-            needs_judgment.append(key)
-        elif verdict == "invalid":
-            invalid_keys.append(key)
-        elif verdict == "valid_optional":
-            optional_keys.append(key)
-    return CommentTriage(
-        bookkeeping=bookkeeping,
-        actionable_keys=actionable,
-        needs_judgment_keys=needs_judgment,
-        unresolved_keys=unresolved,
-        invalid_keys=invalid_keys,
-        optional_keys=optional_keys,
-    )
 
 
 # "could not resolve to" matches GitHub GraphQL missing-resource errors
@@ -590,7 +538,7 @@ def reconcile_pr_run(
     reality: PrReality,
     db_client,
     *,
-    assign_fix: Callable[[AgentRun, PrReality], None] | None = None,
+    assign_fix: Callable[[AgentRun, PrReality, list], None] | None = None,
     dispatch_handoff: Callable[[AgentRun, PrReality, list], bool] | None = None,
     validate_comment: Callable[[ReviewComment], str] = default_validate_comment,
 ) -> AgentRun:
@@ -631,31 +579,56 @@ def reconcile_pr_run(
             metadata={"pr_watcher": {"verified": True, "closed": True}},
         )
 
-    prior_bookkeeping = {}
-    if isinstance(run.metadata, Mapping):
-        prior_bookkeeping = run.metadata.get("pr_review_comments") or {}
-    triage = triage_review_comments(
-        reality.review_comments, prior_bookkeeping, validate_comment,
-    )
+    # Merged wins over all review-comment handling.
+    if reality.merged:
+        return db_client.mark_done(
+            run.repository_full_name,
+            run.github_issue_number,
+            metadata={"pr_watcher": {"verified": True, "merged": True}},
+        )
 
-    # Only validated must-fix comments that have not yet been auto-fixed are
-    # eligible to trigger a fix. The legacy reality.must_fix_review_comments
-    # signal no longer drives fixing directly: those raw comments are routed
-    # through the validation gate as ReviewComment objects instead.
-    must_fix = bool(triage.actionable_keys)
-    decision = decide_pr_watch_phase(
-        pr_merged=reality.merged,
-        ci_green=reality.ci_green,
-        must_fix_review_comments=must_fix,
-        pr_review_fix_rounds=run.pr_review_fix_rounds,
-    )
+    # Upsert every detected comment so the table reflects what the watcher saw
+    # this pass. ``upsert_review_comment`` preserves the PM-owned resolution
+    # columns and refreshes only what the watcher observes.
+    repo = run.repository_full_name
+    issue = run.github_issue_number
+    for comment in reality.review_comments:
+        verdict = validate_comment(comment)
+        if verdict not in REVIEW_VERDICTS:
+            verdict = "needs_user_judgment"
+        db_client.upsert_review_comment(
+            repo,
+            issue,
+            github_comment_id=comment.github_comment_id,
+            body_hash=comment.body_hash[:12],
+            pr_number=reality.pr_number,
+            source=db_source(comment.source),
+            watcher_verdict=verdict,
+            original_body=comment.body or None,
+            original_path=comment.path,
+            original_line=comment.line,
+        )
 
-    # Mark the fresh actionable comments as attempted only when this pass is
-    # actually going to assign a fix round, so each comment id+hash is auto-
-    # fixed at most once across passes.
-    if decision.increment_fix_rounds:
-        for key in triage.actionable_keys:
-            triage.bookkeeping[key]["attempted"] = True
+    # Decide from the DURABLE table state, not only this pass's fetch. A comment
+    # handed off on a prior pass that the PM never resolved must keep blocking
+    # even when a later (possibly partial / transient) GitHub fetch returns
+    # fewer or no comments -- the table, not ``metadata.pr_review_comments`` and
+    # not the current fetch, is the source of truth. A PM resolution
+    # (addressed/rejected) recorded in the table likewise survives across passes,
+    # so a re-armed PR is no longer re-blocked on a comment the PM handled.
+    durable = [
+        r for r in db_client.list_review_comments(repo, issue)
+        if r.pr_number == reality.pr_number
+    ]
+
+    # Partition by durable resolution state. addressed/rejected never block;
+    # unresolved comments are actionable only by their watcher_verdict.
+    escalated = [r for r in durable if r.resolution_status == "needs_user_judgment"]
+    unresolved = [r for r in durable if r.resolution_status == "unresolved"]
+    must_fix_unresolved = [r for r in unresolved if r.watcher_verdict == "valid_must_fix"]
+    judgment_unresolved = [r for r in unresolved if r.watcher_verdict == "needs_user_judgment"]
+    judgment_fresh = [r for r in judgment_unresolved if r.handed_off_at is None]
+    judgment_stale = [r for r in judgment_unresolved if r.handed_off_at is not None]
 
     metadata = {
         "pr_watcher": {
@@ -663,132 +636,118 @@ def reconcile_pr_run(
             "pr_number": reality.pr_number,
             "head_branch": reality.head_branch,
             "ci_green": reality.ci_green,
-            "must_fix_review_comments": reality.must_fix_review_comments,
-            "must_fix_review_comment_count": len(reality.must_fix_comment_keys),
-            "must_fix_comment_keys": list(reality.must_fix_comment_keys[:20]),
             "merged": reality.merged,
             "closed": reality.closed,
-            "review_comment_triage": {
-                "actionable": list(triage.actionable_keys),
-                "unresolved": list(triage.unresolved_keys),
-                "needs_user_judgment": list(triage.needs_judgment_keys),
-                "invalid": list(triage.invalid_keys),
-                "valid_optional": list(triage.optional_keys),
+            "review_comments": {
+                "total": len(durable),
+                "must_fix_unresolved": [r.comment_key for r in must_fix_unresolved],
+                "needs_user_judgment_unresolved": [
+                    r.comment_key for r in judgment_unresolved
+                ],
+                "escalated_to_user": [r.comment_key for r in escalated],
                 "handed_off": [
-                    k for k in triage.needs_judgment_keys
-                    if triage.bookkeeping.get(k, {}).get("handed_off")
+                    r.comment_key for r in durable if r.handed_off_at is not None
+                ],
+                "addressed": [
+                    r.comment_key for r in durable
+                    if r.resolution_status == "addressed"
+                ],
+                "rejected": [
+                    r.comment_key for r in durable
+                    if r.resolution_status == "rejected"
                 ],
             },
         },
-        "pr_review_comments": triage.bookkeeping,
     }
 
-    # Merged wins over everything else.
-    if decision.phase == "done":
-        return db_client.mark_done(
-            run.repository_full_name,
-            run.github_issue_number,
-            metadata=metadata,
-        )
+    decision = decide_pr_watch_phase(
+        pr_merged=False,
+        ci_green=reality.ci_green,
+        must_fix_review_comments=bool(must_fix_unresolved),
+        pr_review_fix_rounds=run.pr_review_fix_rounds,
+    )
 
-    # A fresh validated must-fix with budget left: assign exactly one fix round.
-    if decision.phase == "fixing":
+    # 1. A fresh validated must-fix with fix budget: assign exactly one fix round
+    #    for the must-fix keys only. needs_user_judgment / optional / invalid
+    #    comments present in the same fetch are NOT swept into the fix prompt;
+    #    they keep their own (handoff / block / non-blocking) paths.
+    if must_fix_unresolved and decision.phase == "fixing":
+        must_fix_keys = [r.comment_key for r in must_fix_unresolved]
         updated = db_client.update_pr_fields(
-            run.repository_full_name,
-            run.github_issue_number,
+            repo,
+            issue,
             pr_number=reality.pr_number,
-            status=decision.phase,
+            status="fixing",
             increment_fix_rounds=decision.increment_fix_rounds,
             metadata=metadata,
         )
         if assign_fix is not None:
-            assign_fix(updated, reality)
+            assign_fix(updated, reality, must_fix_keys)
         return updated
 
-    # Not fixing this pass. A validated must-fix that was already attempted but
-    # is still present must NOT slip through to ready_to_merge: it cannot be
-    # auto-fixed again, so escalate to a human.
-    if triage.unresolved_keys:
+    # 2. A validated must-fix still unresolved after the one allowed auto-fix
+    #    round: it cannot be auto-fixed again and must not slip to ready_to_merge.
+    if must_fix_unresolved and decision.phase == "blocked":
         reason = (
             "valid must-fix PR review comments remain after the automated fix "
-            "attempt: " + ", ".join(triage.unresolved_keys[:20])
+            "attempt: " + ", ".join(r.comment_key for r in must_fix_unresolved[:20])
         )
-        return db_client.mark_blocked(
-            run.repository_full_name,
-            run.github_issue_number,
-            reason,
-            metadata=metadata,
-        )
+        return db_client.mark_blocked(repo, issue, reason, metadata=metadata)
 
-    # Comments needing a human/agent decision. With a live ``dispatch_handoff``
-    # the watcher hands the *fresh* (not-yet-dispatched) keys to the existing PM
-    # pane for validation+fix instead of dead-ending. Keys already handed off
-    # but still ambiguous escalate to a human rather than being re-sent every
-    # tick. Without a dispatcher (the conservative default / unit tests) this
-    # still blocks for user judgment.
-    if triage.needs_judgment_keys:
-        fresh = [
-            k for k in triage.needs_judgment_keys
-            if not triage.bookkeeping.get(k, {}).get("handed_off")
-        ]
-        if fresh and dispatch_handoff is not None:
-            # Deliver the validation prompt first; only persist the handoff if
-            # delivery succeeded so a transient tmux failure is retried next
-            # tick rather than silently consuming the one-shot handoff.
-            delivered = dispatch_handoff(run, reality, fresh)
+    # 3. PM explicitly escalated a comment to a human, or a comment was handed
+    #    off but the PM re-armed the watcher without recording a resolution.
+    #    Either way a human must decide; do not re-handoff in a loop.
+    blocking_keys = [r.comment_key for r in (escalated + judgment_stale)]
+    if blocking_keys:
+        reason = (
+            "PR review comments need user judgment before automated handling: "
+            + ", ".join(blocking_keys[:20])
+        )
+        return db_client.mark_blocked(repo, issue, reason, metadata=metadata)
+
+    # 4. Fresh needs_user_judgment comments: hand them to the existing PM pane
+    #    once. A successful delivery stamps handed_off_at and parks the run in
+    #    'fixing' until the PM records a resolution and re-arms via mark_pr_open;
+    #    the same key, if still unresolved on re-entry, escalates at step 3.
+    if judgment_fresh:
+        fresh_keys = [r.comment_key for r in judgment_fresh]
+        if dispatch_handoff is not None:
+            delivered = dispatch_handoff(run, reality, fresh_keys)
             if delivered:
-                for key in fresh:
-                    triage.bookkeeping[key]["handed_off"] = True
-                metadata["pr_watcher"]["review_comment_triage"]["handed_off"] = [
-                    k for k in triage.needs_judgment_keys
-                    if triage.bookkeeping.get(k, {}).get("handed_off")
-                ]
-                # Park the run out of the watch set while the PM validates/fixes.
-                # The handoff prompt instructs the PM to re-arm via mark_pr_open
-                # (status -> pr_open) when done, so the watcher re-checks; if the
-                # same keys are still ambiguous then, they will have handed_off
-                # set and escalate below instead of looping.
+                for r in judgment_fresh:
+                    db_client.mark_review_comment_handed_off(repo, issue, r.comment_key)
+                metadata["pr_watcher"]["review_comments"]["handed_off"] = sorted(
+                    set(metadata["pr_watcher"]["review_comments"]["handed_off"])
+                    | set(fresh_keys)
+                )
                 return db_client.update_pr_fields(
-                    run.repository_full_name,
-                    run.github_issue_number,
+                    repo,
+                    issue,
                     pr_number=reality.pr_number,
                     status="fixing",
                     metadata=metadata,
                 )
-            # Delivery failed: keep watching and retry next pass (handed_off
+            # Delivery failed: keep watching and retry next pass (handed_off_at
             # stays unset for these keys).
             return db_client.update_pr_fields(
-                run.repository_full_name,
-                run.github_issue_number,
+                repo,
+                issue,
                 pr_number=reality.pr_number,
                 status="pr_watching",
                 metadata=metadata,
             )
         reason = (
             "PR review comments need user judgment before automated handling: "
-            + ", ".join(triage.needs_judgment_keys[:20])
+            + ", ".join(fresh_keys[:20])
         )
-        return db_client.mark_blocked(
-            run.repository_full_name,
-            run.github_issue_number,
-            reason,
-            metadata=metadata,
-        )
+        return db_client.mark_blocked(repo, issue, reason, metadata=metadata)
 
-    # Round-cap block (fresh actionable must-fix but no budget left).
-    if decision.phase == "blocked":
-        return db_client.mark_blocked(
-            run.repository_full_name,
-            run.github_issue_number,
-            decision.block_reason,
-            metadata=metadata,
-        )
+    # 5. Nothing actionable/unresolved remains: CI state gates ready_to_merge.
     return db_client.update_pr_fields(
-        run.repository_full_name,
-        run.github_issue_number,
+        repo,
+        issue,
         pr_number=reality.pr_number,
         status=decision.phase,
-        increment_fix_rounds=decision.increment_fix_rounds,
         metadata=metadata,
     )
 
@@ -797,7 +756,7 @@ def check_once(
     db_client,
     *,
     fetch_reality: Callable[[str, int], PrReality] = fetch_pr_reality,
-    assign_fix: Callable[[AgentRun, PrReality], None] | None = None,
+    assign_fix: Callable[[AgentRun, PrReality, list], None] | None = None,
     dispatch_handoff: Callable[[AgentRun, PrReality, list], bool] | None = None,
     validate_comment: Callable[[ReviewComment], str] = default_validate_comment,
 ) -> list[AgentRun]:
@@ -845,12 +804,12 @@ def check_once(
 # that already owns the run (``run.pm_pane`` / ``pm_pane_target(run.tmux_window)``)
 # using the same tmux delivery primitive the launcher uses to seed the PM.
 #
-# Duplicate handoffs are prevented by the per-comment ``handed_off`` flag in
-# ``pr_review_comments`` bookkeeping: only keys without it are dispatched, and a
-# successful delivery parks the run in ``status='fixing'`` so it leaves the watch
-# set until the PM re-arms it via ``mark_pr_open`` (status -> ``pr_open``). The
-# same key, if still ambiguous on re-entry, escalates to a human instead of
-# being re-sent.
+# Duplicate handoffs are prevented by the ``review_comments.handed_off_at``
+# column: only comments without it are dispatched, and a successful delivery
+# stamps it and parks the run in ``status='fixing'`` so it leaves the watch set
+# until the PM records a resolution and re-arms via ``mark_pr_open`` (status ->
+# ``pr_open``). The same key, if still ``unresolved`` on re-entry, escalates to a
+# human instead of being re-sent.
 
 
 # Directory containing the ``u_agents`` package (the dotfiles checkout root is
@@ -872,6 +831,27 @@ def mark_pr_open_command(repository_full_name: str, issue_number: int, pr_number
     return (
         f"PYTHONPATH={root} {python} -m u_agents.mark_pr_open "
         f"--repo {repository_full_name} --issue {issue_number} --pr {pr_number}"
+    )
+
+
+def record_resolution_command(
+    repository_full_name: str, issue_number: int, comment_key: str
+) -> str:
+    """Exact, shell-quoted command the PM runs to persist one comment's
+    resolution in ``review_comments`` before re-arming the watcher.
+
+    Mirrors ``mark_pr_open_command``: an explicit ``PYTHONPATH`` and the running
+    interpreter (which already imported psycopg), since the PM runs this from the
+    target repo worktree where ``u_agents`` is not on the path.
+    """
+    root = shlex.quote(str(_PACKAGE_DIR.parent))
+    python = shlex.quote(sys.executable)
+    key = shlex.quote(str(comment_key))
+    return (
+        f"PYTHONPATH={root} {python} -m u_agents.record_review_comment_resolution "
+        f"--repo {repository_full_name} --issue {issue_number} --comment-key {key} "
+        "--resolution-status <addressed|rejected|needs_user_judgment> "
+        "--pm-decision <verdict> [--commit-sha <sha>] --verification-summary <text>"
     )
 
 
@@ -909,6 +889,10 @@ def build_validation_handoff_prompt(
     rearm = mark_pr_open_command(
         run.repository_full_name, run.github_issue_number, reality.pr_number,
     )
+    record_lines = "\n".join(
+        f"       {record_resolution_command(run.repository_full_name, run.github_issue_number, key)}"
+        for key in keys
+    )
     return (
         "u-agents PR watcher handoff: validate PR review comments for "
         f"{run.repository_full_name}#{run.github_issue_number} "
@@ -944,36 +928,58 @@ def build_validation_handoff_prompt(
         "5. Address every valid_must_fix comment. Address each comment (by its "
         "[id:hash] key above) at most once; if you already addressed that exact "
         "key in a previous round, do not redo it.\n"
-        "6. Record your verdict for each key in your PR/issue report "
-        "(key -> verdict + one-line reason). For invalid / valid_optional / "
-        "needs_user_judgment the reason must justify NOT fixing it.\n"
-        "7. After addressing valid_must_fix comments and pushing, re-arm the "
-        "watcher by running exactly this full command; do not replace it with "
-        "a bare interpreter invocation:\n"
+        "6. Record a DURABLE resolution in the DB for EACH key BEFORE re-arming. "
+        "The watcher reads the review_comments table, NOT your PR/issue comment "
+        "text, so a verdict written only in a comment does not count and the run "
+        "will be re-blocked. Run exactly one of these per key (fill in the "
+        "status/decision/evidence):\n"
+        f"{record_lines}\n"
+        "   - resolution-status addressed requires --commit-sha and "
+        "--verification-summary (what you changed + how you verified it).\n"
+        "   - resolution-status rejected or needs_user_judgment requires "
+        "--verification-summary as the reason for not fixing.\n"
+        "7. Only AFTER recording a resolution for every key (and pushing any "
+        "fixes) re-arm the watcher by running exactly this full command; do not "
+        "replace it with a bare interpreter invocation:\n"
         f"       {rearm}\n"
-        "8. For needs_user_judgment comments, comment on the issue asking the "
+        "8. For needs_user_judgment comments, record resolution-status "
+        "needs_user_judgment with the reason AND comment on the issue asking the "
         "user; do not guess and do not silently skip.\n"
     )
 
 
-def build_fix_prompt(run: AgentRun, reality: PrReality) -> str:
+def build_fix_prompt(run: AgentRun, reality: PrReality, keys: list) -> str:
     """Prompt for the valid_must_fix path (used when an explicit validator has
-    already confirmed must-fix comments). Lists all current review comments and
-    asks the PM to address the validated must-fix ones and re-arm the watcher.
+    already confirmed must-fix comments).
+
+    ``keys`` are exactly the must-fix comment keys assigned this round. The
+    listing and the per-key record-resolution commands cover only those keys, so
+    needs_user_judgment / optional / invalid comments present in the same fetch
+    are NOT swept into the must-fix repair prompt; they keep their own handoff /
+    block / non-blocking paths.
     """
-    keys = [c.stable_key for c in reality.review_comments]
     listing = _format_comment_lines(reality, keys)
     rearm = mark_pr_open_command(
         run.repository_full_name, run.github_issue_number, reality.pr_number,
+    )
+    record_lines = "\n".join(
+        f"       {record_resolution_command(run.repository_full_name, run.github_issue_number, key)}"
+        for key in keys
     )
     return (
         "u-agents PR watcher: address validated must-fix review comments for "
         f"{run.repository_full_name}#{run.github_issue_number} "
         f"(PR #{reality.pr_number}).\n\n"
         f"{listing}\n\n"
-        "Address each validated must-fix comment exactly once, push, then "
-        "re-arm the watcher by running exactly this full command; do not "
-        "replace it with a bare interpreter invocation:\n"
+        "Address each validated must-fix comment exactly once and push. Then, "
+        "BEFORE re-arming, record a durable resolution in the DB for each key "
+        "(the watcher reads review_comments, not your comment text); for an "
+        "addressed comment pass --resolution-status addressed --commit-sha "
+        "<sha> --verification-summary <text>:\n"
+        f"{record_lines}\n"
+        "Only after recording resolutions re-arm the watcher by running exactly "
+        "this full command; do not replace it with a bare interpreter "
+        "invocation:\n"
         f"       {rearm}\n"
     )
 
@@ -1012,9 +1018,9 @@ def live_dispatch_handoff(run: AgentRun, reality: PrReality, keys: list) -> bool
     return _send_pm_prompt(run, build_validation_handoff_prompt(run, reality, keys))
 
 
-def live_assign_fix(run: AgentRun, reality: PrReality) -> None:
-    """Production fix dispatch for the valid_must_fix path."""
-    _send_pm_prompt(run, build_fix_prompt(run, reality))
+def live_assign_fix(run: AgentRun, reality: PrReality, keys: list) -> None:
+    """Production fix dispatch for the valid_must_fix path (assigned keys only)."""
+    _send_pm_prompt(run, build_fix_prompt(run, reality, keys))
 
 
 def main(argv=None) -> int:

--- a/u_agents/prompts/pm.md
+++ b/u_agents/prompts/pm.md
@@ -142,6 +142,33 @@ watchdog recovery path apply. Do not open a PR from pane output alone.
      - review result:
      - next action needed:
 
+# PR review comment resolution
+
+If the PR watcher hands you PR review comments to validate (it sends a prompt
+listing each comment by a stable `id:body-hash` key), the watcher decides solely
+from the `review_comments` DB table, NOT from anything you write in a GitHub PR
+or issue comment. So you must record a durable resolution in the DB for every
+handed-off key BEFORE you re-arm the watcher with `mark_pr_open`.
+
+For each handed-off key, after validating (and fixing valid_must_fix comments),
+run exactly this command (explicit `PYTHONPATH` and interpreter, same reasons as
+`mark_pr_open` above):
+
+    PYTHONPATH={u_agents_root} {u_agents_python} -m u_agents.record_review_comment_resolution --repo {repo_full} --issue {issue_number} --comment-key <id:hash> --resolution-status <addressed|rejected|needs_user_judgment> --pm-decision <verdict> [--commit-sha <sha>] --verification-summary <text>
+
+- `addressed` requires `--commit-sha` and `--verification-summary` (what you
+  changed and how you verified it). The DB rejects an `addressed` row without
+  both.
+- `rejected` / `needs_user_judgment` require `--verification-summary` as the
+  reason for not fixing it.
+- For `needs_user_judgment`, also comment on the issue asking the user.
+
+Only after recording a resolution for every handed-off key (and pushing any
+fixes) re-arm the watcher with the `u_agents.mark_pr_open` command from step 6.
+If you re-arm without recording resolutions, the watcher sees the same
+handed-off comment still `unresolved` and blocks the run. `mark_pr_open` only
+re-arms the watcher; it does not record any review comment resolution.
+
 # Watchdog protocol
 
 A separate watchdog watches your pane output. If your pane is unchanged

--- a/u_agents/record_review_comment_resolution.py
+++ b/u_agents/record_review_comment_resolution.py
@@ -36,6 +36,7 @@ import sys
 from u_agents.agent_runs import (
     AgentRunsClient,
     ReviewCommentRecord,
+    validate_comment_key,
     validate_pm_decision,
     validate_review_comment_resolution,
     validate_verification_refs,
@@ -125,6 +126,7 @@ def main(argv=None) -> int:
     # Validate cross-field rules before opening a DB connection so an invalid
     # request fails fast with a clear CLI error (exit 2), not a DB round-trip.
     try:
+        validate_comment_key(args.comment_key)
         validate_pm_decision(args.pm_decision)
         validate_verification_refs(args.verification_refs)
         validate_review_comment_resolution(

--- a/u_agents/record_review_comment_resolution.py
+++ b/u_agents/record_review_comment_resolution.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""CLI for the PM to persist a PR review comment resolution in ``review_comments``.
+
+After the PR watcher hands a review comment to the PM, the PM validates it,
+optionally fixes it, and must record the outcome durably **before** re-arming the
+watcher with ``u_agents.mark_pr_open``. Writing a verdict only into a GitHub
+comment is not durable state: the watcher reads ``review_comments`` (not GitHub
+comment bodies), so an unrecorded resolution makes the watcher re-block the run
+on the same handed-off comment.
+
+Each comment is identified by its stable ``comment_key`` (``id:body-hash``), the
+same key the watcher hand-off prompt lists. Example (run from the issue
+worktree, where ``u_agents`` is not on the path and ``python3`` may lack
+psycopg):
+
+    PYTHONPATH=/path/to/dotfiles /path/to/python -m u_agents.record_review_comment_resolution \\
+        --repo owner/name --issue 32 --comment-key 3409641728:1cf66a90f911 \\
+        --resolution-status addressed --pm-decision valid_must_fix \\
+        --commit-sha b6cd1ad --verification-summary "guarded with context.mounted; flutter test green"
+
+Rules enforced here (and again by the DB):
+
+- ``addressed`` requires ``--commit-sha`` and ``--verification-summary``.
+- ``rejected`` / ``needs_user_judgment`` require ``--verification-summary`` as
+  the reason for not fixing.
+
+Live runs require ``U_AGENTS_DATABASE_URL``, ``U_AGENTS_RUNNER_ID``,
+``U_AGENTS_MACHINE_ID``, ``psycopg``, and reachable Postgres. ``--help`` does not
+import psycopg.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from u_agents.agent_runs import (
+    AgentRunsClient,
+    ReviewCommentRecord,
+    validate_pm_decision,
+    validate_review_comment_resolution,
+    validate_verification_refs,
+)
+from u_agents.control_plane import (
+    REVIEW_COMMENT_RESOLUTION_STATUSES,
+    REVIEW_COMMENT_VERDICTS,
+)
+
+
+def record_resolution(
+    db_client,
+    repository_full_name: str,
+    github_issue_number: int,
+    comment_key: str,
+    *,
+    resolution_status: str,
+    pm_decision: str | None = None,
+    addressed_by_commit_sha: str | None = None,
+    verification_summary: str | None = None,
+    verification_refs=None,
+) -> ReviewCommentRecord:
+    """Persist the resolution via the shared client method.
+
+    Kept separate from ``main`` so it can be unit-tested with a fake client
+    without touching ``AgentRunsClient.from_env`` / psycopg.
+    """
+    return db_client.record_review_comment_resolution(
+        repository_full_name,
+        github_issue_number,
+        comment_key,
+        resolution_status=resolution_status,
+        pm_decision=pm_decision,
+        addressed_by_commit_sha=addressed_by_commit_sha,
+        verification_summary=verification_summary,
+        verification_refs=verification_refs,
+    )
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(
+        description=(
+            "Record a PR review comment resolution in review_comments so the "
+            "PR watcher stops re-blocking on a handed-off comment."
+        )
+    )
+    p.add_argument("--repo", required=True, help="GitHub repository owner/name")
+    p.add_argument("--issue", required=True, type=int, help="GitHub issue number")
+    p.add_argument(
+        "--comment-key",
+        required=True,
+        help="Stable comment identity (github_comment_id:body_hash)",
+    )
+    p.add_argument(
+        "--resolution-status",
+        required=True,
+        choices=list(REVIEW_COMMENT_RESOLUTION_STATUSES),
+        help="Durable PM resolution status",
+    )
+    p.add_argument(
+        "--pm-decision",
+        choices=list(REVIEW_COMMENT_VERDICTS),
+        help="PM verdict about the comment (optional)",
+    )
+    p.add_argument(
+        "--commit-sha",
+        dest="commit_sha",
+        help="Commit sha that addressed the comment (required for 'addressed')",
+    )
+    p.add_argument(
+        "--verification-summary",
+        dest="verification_summary",
+        help=(
+            "Short verification/justification summary (required for "
+            "'addressed', and as the reason for 'rejected'/'needs_user_judgment')"
+        ),
+    )
+    p.add_argument(
+        "--verification-ref",
+        dest="verification_refs",
+        action="append",
+        default=None,
+        help="Durable evidence pointer (URL/path); repeatable",
+    )
+    args = p.parse_args(argv)
+
+    # Validate cross-field rules before opening a DB connection so an invalid
+    # request fails fast with a clear CLI error (exit 2), not a DB round-trip.
+    try:
+        validate_pm_decision(args.pm_decision)
+        validate_verification_refs(args.verification_refs)
+        validate_review_comment_resolution(
+            args.resolution_status,
+            addressed_by_commit_sha=args.commit_sha,
+            verification_summary=args.verification_summary,
+        )
+    except ValueError as e:
+        p.error(str(e))
+
+    db_client = AgentRunsClient.from_env()
+    try:
+        record = record_resolution(
+            db_client,
+            args.repo,
+            args.issue,
+            args.comment_key,
+            resolution_status=args.resolution_status,
+            pm_decision=args.pm_decision,
+            addressed_by_commit_sha=args.commit_sha,
+            verification_summary=args.verification_summary,
+            verification_refs=args.verification_refs,
+        )
+    finally:
+        db_client.close()
+    print(
+        f"{args.repo}#{args.issue}: review comment {record.comment_key} "
+        f"resolution_status={record.resolution_status} "
+        f"pm_decision={record.pm_decision}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #20.

Adds a normalized `review_comments` table as the durable source of truth for u_agents PR review comment workflow state. The PR watcher now persists observed review comments, reads table-backed resolution state when deciding whether to fix, hand off, block, or mark ready, and requires PM resolutions to be recorded before re-arming the watcher.

## Changes

- Add `u_agents/db/003_review_comments.sql` with generated `comment_key`, ownership constraints, indexes, and updated-at trigger.
- Add `AgentRunsClient` review comment APIs for upsert, handoff stamping, PM resolution recording, and listing durable rows.
- Add `python -m u_agents.record_review_comment_resolution` for PM-owned durable resolutions.
- Update `pr_watcher` and PM prompts so `metadata.pr_review_comments` is no longer the source of truth and `mark_pr_open` remains re-arm only.
- Cover table-backed blackbox flows, empty/partial GitHub fetches, mixed verdict handling, CLI validation, and DB contract rules.

## Verification

- `python3 -m unittest tests.test_db_contract tests.test_agent_runs tests.test_pr_watcher tests.test_record_review_comment_resolution tests.test_pm_prompt`
- `python3 -m unittest discover tests`
- `git diff --check`
- Applied migrations `001 -> 002 -> 003` to a throwaway Postgres 17 container and verified terminal-resolution constraints reject missing reasons.
