### PR TITLE
Enable shared Groq PR review

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,16 @@
+name: AI Review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, review_requested]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  review:
+    uses: uuta/github-workflows/.github/workflows/pr-review.yml@a2e0f4d8aa6ca1492f08798cd80bbfc8d3dc0922
+    secrets:
+      groq_api_key: ${{ secrets.GROQ_API_KEY }}


### PR DESCRIPTION
## Summary

- Add the shared Groq-backed PR review caller.
- Pin the reusable workflow to immutable commit a2e0f4d8aa6ca1492f08798cd80bbfc8d3dc0922.
- Pass only the repository GROQ_API_KEY secret with least-privilege permissions.

## Verification

- YAML parse passed.
- Workflow contract, fixed pin, forbidden-pattern, and whitespace checks passed.
- The diff is limited to the AI review caller.
