### PR TITLE
ci: migrate AI review to OpenRouter

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   review:
-    uses: uuta/github-workflows/.github/workflows/pr-review.yml@a2e0f4d8aa6ca1492f08798cd80bbfc8d3dc0922
+    uses: uuta/github-workflows/.github/workflows/pr-review.yml@349ea25effcdcddd767b8bb5b303ed41642b5b65
     secrets:
-      groq_api_key: ${{ secrets.GROQ_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
## Summary

- pin the shared PR review workflow to the OpenRouter migration merge commit
- map `OPENROUTER_API_KEY` explicitly from the repository secret
- preserve the existing PR triggers and least-privilege permissions

## Verification

- YAML parses successfully
- reusable workflow is pinned to the full 40-character SHA
- exact OpenRouter secret mapping verified
- forbidden workflow patterns are absent
- `git diff --check` passes
- only `.github/workflows/ai-review.yml` changed