### PR TITLE
ci: track uuta/github-workflows@main for reusable pr-review workflow

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   review:
-    uses: uuta/github-workflows/.github/workflows/pr-review.yml@349ea25effcdcddd767b8bb5b303ed41642b5b65
+    uses: uuta/github-workflows/.github/workflows/pr-review.yml@main
     secrets:
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
This switches the consumer workflow to track @main in our own uuta/github-workflows repository so reusable review updates propagate automatically; the third-party The-PR-Agent/pr-agent action remains pinned to a full commit SHA inside that central workflow, and these PRs also provide the first live test of the new GLM-5.2 review configuration.